### PR TITLE
Custom location and ability to add custom attributes to the signature

### DIFF
--- a/lib/signed-xml.js
+++ b/lib/signed-xml.js
@@ -395,17 +395,21 @@ SignedXml.prototype.addReference = function(xpath, transforms, digestAlgorithm, 
  * Options:
  *
  * - `prefix` {String} Adds a prefix for the generated signature tags
+ * - `attrs` {Object} A hash of attributes and values `attrName: value` to add to the signature root node
  *
  */
 SignedXml.prototype.computeSignature = function(xml, opts) {
   var doc = new Dom().parseFromString(xml),
       xmlNsAttr = 'xmlns',
+      signatureAttrs = [],
       xpathToNodeBeforeSignature,
+      attrs,
       prefix,
       currentPrefix;
 
   opts = opts || {};
   prefix = opts.prefix;
+  attrs = opts.attrs || {};
   xpathToNodeBeforeSignature = opts.xpathToNodeBeforeSignature;
 
   // automatic insertion of `:`
@@ -416,7 +420,16 @@ SignedXml.prototype.computeSignature = function(xml, opts) {
     currentPrefix = '';
   }
 
-  this.signatureXml = "<" + currentPrefix + "Signature " + xmlNsAttr + "=\"http://www.w3.org/2000/09/xmldsig#\">"
+  Object.keys(attrs).forEach(function(name) {
+    if (name !== "xmlns" && name !== xmlNsAttr) {
+      signatureAttrs.push(name + "=\"" + attrs[name] + "\"");
+    }
+  });
+
+  // add the xml namespace attribute
+  signatureAttrs.push(xmlNsAttr + "=\"http://www.w3.org/2000/09/xmldsig#\"");
+
+  this.signatureXml = "<" + currentPrefix + "Signature " + signatureAttrs.join(' ') + ">"
 
   var signedInfo = this.createSignedInfo(doc, prefix);
   this.signatureXml += signedInfo;

--- a/lib/signed-xml.js
+++ b/lib/signed-xml.js
@@ -396,28 +396,44 @@ SignedXml.prototype.addReference = function(xpath, transforms, digestAlgorithm, 
  *
  * - `prefix` {String} Adds a prefix for the generated signature tags
  * - `attrs` {Object} A hash of attributes and values `attrName: value` to add to the signature root node
+ * - `location` {{ reference: String, action: String }}
+ *   A object with a `reference` key which should
+ *   contain an XPath expression, a `action` key which
+ *   should contain one of the following values:
+ *   `append`, `prepend`, `before`, `after`
  *
  */
 SignedXml.prototype.computeSignature = function(xml, opts) {
   var doc = new Dom().parseFromString(xml),
-      xmlNsAttr = 'xmlns',
+      xmlNsAttr = "xmlns",
       signatureAttrs = [],
-      xpathToNodeBeforeSignature,
+      location,
       attrs,
       prefix,
       currentPrefix;
 
+  var validActions = ["append", "prepend", "before", "after"];
+
   opts = opts || {};
   prefix = opts.prefix;
   attrs = opts.attrs || {};
-  xpathToNodeBeforeSignature = opts.xpathToNodeBeforeSignature;
+  location = opts.location || {};
+  // defaults to the root node
+  location.reference = location.reference || "/*";
+  // defaults to append action
+  location.action = location.action || "append";
+
+  if (validActions.indexOf(location.action) === -1) {
+    throw new Error("location.action option has an invalid action: " + location.action +
+                    ", must be any of the following values: " + validActions.join(", "));
+  }
 
   // automatic insertion of `:`
   if (prefix) {
-    xmlNsAttr += ':' + prefix;
-    currentPrefix = prefix + ':';
+    xmlNsAttr += ":" + prefix;
+    currentPrefix = prefix + ":";
   } else {
-    currentPrefix = '';
+    currentPrefix = "";
   }
 
   Object.keys(attrs).forEach(function(name) {
@@ -429,7 +445,7 @@ SignedXml.prototype.computeSignature = function(xml, opts) {
   // add the xml namespace attribute
   signatureAttrs.push(xmlNsAttr + "=\"http://www.w3.org/2000/09/xmldsig#\"");
 
-  this.signatureXml = "<" + currentPrefix + "Signature " + signatureAttrs.join(' ') + ">"
+  this.signatureXml = "<" + currentPrefix + "Signature " + signatureAttrs.join(" ") + ">"
 
   var signedInfo = this.createSignedInfo(doc, prefix);
   this.signatureXml += signedInfo;
@@ -440,17 +456,23 @@ SignedXml.prototype.computeSignature = function(xml, opts) {
   this.originalXmlWithIds = doc.toString()
 
   var signatureDoc = new Dom().parseFromString(this.signatureXml)
-  if (xpathToNodeBeforeSignature) {
-    var nodes = select(doc, xpathToNodeBeforeSignature);
-    if (!nodes && nodes.length === 0) {
-      doc.documentElement.appendChild(signatureDoc.documentElement);
-    } else {
-      var referenceNode = nodes[0];
-      // insert before referenceNode.nextSibling
-      doc.documentElement.insertBefore(signatureDoc.documentElement, referenceNode.nextSibling ? referenceNode.nextSibling : referenceNode);
-    }
-  } else {
-    doc.documentElement.appendChild(signatureDoc.documentElement)
+
+  var referenceNode = select(doc, location.reference);
+
+  if (!referenceNode && referenceNode.length === 0) {
+    throw new Error("the following xpath cannot be used because it was not found: " + location.reference);
+  }
+
+  referenceNode = referenceNode[0];
+
+  if (location.action === "append") {
+    referenceNode.appendChild(signatureDoc.documentElement);
+  } else if (location.action === "prepend") {
+    referenceNode.insertBefore(signatureDoc.documentElement, referenceNode.firstChild);
+  } else if (location.action === "before") {
+    referenceNode.parentNode.insertBefore(signatureDoc.documentElement, referenceNode);
+  } else if (location.action === "after") {
+    referenceNode.parentNode.insertBefore(signatureDoc.documentElement, referenceNode.nextSibling);
   }
 
   this.signedXml = doc.toString()

--- a/lib/signed-xml.js
+++ b/lib/signed-xml.js
@@ -392,11 +392,21 @@ SignedXml.prototype.addReference = function(xpath, transforms, digestAlgorithm, 
 /**
  * Compute the signature of the given xml (usign the already defined settings)
  *
+ * Options:
+ *
+ * - `prefix` {String} Adds a prefix for the generated signature tags
+ *
  */
-SignedXml.prototype.computeSignature = function(xml, xpathToNodeBeforeSignature, prefix) {
+SignedXml.prototype.computeSignature = function(xml, opts) {
   var doc = new Dom().parseFromString(xml),
       xmlNsAttr = 'xmlns',
+      xpathToNodeBeforeSignature,
+      prefix,
       currentPrefix;
+
+  opts = opts || {};
+  prefix = opts.prefix;
+  xpathToNodeBeforeSignature = opts.xpathToNodeBeforeSignature;
 
   // automatic insertion of `:`
   if (prefix) {

--- a/test/signature-unit-tests.js
+++ b/test/signature-unit-tests.js
@@ -4,26 +4,26 @@ var select = require('xpath.js')
   , FileKeyInfo = require('../lib/signed-xml.js').FileKeyInfo
   , xml_assert = require('./xml-assert.js')
   , fs = require('fs')
-  
-module.exports = {    
 
-  "signer adds increasing id atributes to elements": function (test) {    
+module.exports = {
+
+  "signer adds increasing id atributes to elements": function (test) {
     verifyAddsId(test, "wssecurity", "equal")
-    verifyAddsId(test, null, "different") 
-    test.done();   
+    verifyAddsId(test, null, "different")
+    test.done();
   },
 
 
   "signer does not duplicate existing id attributes": function (test) {
     verifyDoesNotDuplicateIdAttributes(test, null, "")
     verifyDoesNotDuplicateIdAttributes(test, "wssecurity", "wsu:")
-    
+
     test.done();
   },
 
 
   "signer creates signature with correct structure": function(test) {
-    
+
     function DummyKeyInfo() {
       this.getKeyInfo = function(key) {
         return "dummy key info"
@@ -31,8 +31,8 @@ module.exports = {
     }
 
     function DummyDigest() {
-  
-      this.getHash = function(xml) {    
+
+      this.getHash = function(xml) {
         return "dummy digest"
       }
 
@@ -42,8 +42,8 @@ module.exports = {
     }
 
     function DummySignatureAlgorithm() {
-  
-      this.getSignature = function(xml, signingKey) {            
+
+      this.getSignature = function(xml, signingKey) {
         return "dummy signature"
       }
 
@@ -71,7 +71,7 @@ module.exports = {
        this.getAlgorithmName = function() {
         return "dummy canonicalization"
       }
-    } 
+    }
 
     var xml = "<root><x xmlns=\"ns\"></x><y attr=\"value\"></y><z><w></w></z></root>"
     var sig = new SignedXml()
@@ -124,7 +124,7 @@ module.exports = {
                   "</KeyInfo>"+
                   "</Signature>"
 
-   
+
     test.equal(expected, signature, "wrong signature format")
 
     var signedXml = sig.getSignedXml()
@@ -242,7 +242,7 @@ module.exports = {
     sig.addReference("//*[local-name(.)='y']", ["http://DummyTransformation"], "http://dummyDigest")
     sig.addReference("//*[local-name(.)='w']", ["http://DummyTransformation"], "http://dummyDigest")
 
-    sig.computeSignature(xml, null, prefix);
+    sig.computeSignature(xml, { prefix: prefix });
     var signature = sig.getSignatureXml()
 
     var expected = "<ds:Signature xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\">"+
@@ -368,33 +368,33 @@ module.exports = {
                     "<SignatureValue>NejzGB9MDUddKCt3GL2vJhEd5q6NBuhLdQc3W4bJI5q34hk7Hk6zBRoW3OliX+/f7Hpi9y0INYoqMSUfrsAVm3IuPzUETKlI6xiNZo07ULRj1DwxRo6cU66ar1EKUQLRuCZas795FjB8jvUI2lyhcax/00uMJ+Cjf4bwAQ+9gOQ=</SignatureValue>" +
                     "</Signature>" +
                     "</root>"
-   
+
     test.equal(expected, signedXml, "wrong signature format")
 
     test.done();
   },
- 
 
- 
+
+
   "correctly loads signature": function(test) {
     var xml = fs.readFileSync("./test/static/valid_signature.xml").toString()
-    var doc = new dom().parseFromString(xml)    
+    var doc = new dom().parseFromString(xml)
     var node = select(doc, "/*//*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")[0]
-    var sig = new SignedXml() 
+    var sig = new SignedXml()
     sig.loadSignature(node.toString())
 
 
 
-    test.equal("http://www.w3.org/2001/10/xml-exc-c14n#", 
-      sig.canonicalizationAlgorithm, 
+    test.equal("http://www.w3.org/2001/10/xml-exc-c14n#",
+      sig.canonicalizationAlgorithm,
       "wrong canonicalization method")
-    
-    test.equal("http://www.w3.org/2000/09/xmldsig#rsa-sha1", 
-      sig.signatureAlgorithm, 
+
+    test.equal("http://www.w3.org/2000/09/xmldsig#rsa-sha1",
+      sig.signatureAlgorithm,
       "wrong signature method")
 
-    test.equal("PI2xGt3XrVcxYZ34Kw7nFdq75c7Mmo7J0q7yeDhBprHuJal/KV9KyKG+Zy3bmQIxNwkPh0KMP5r1YMTKlyifwbWK0JitRCSa0Fa6z6+TgJi193yiR5S1MQ+esoQT0RzyIOBl9/GuJmXx/1rXnqrTxmL7UxtqKuM29/eHwF0QDUI=", 
-      sig.signatureValue, 
+    test.equal("PI2xGt3XrVcxYZ34Kw7nFdq75c7Mmo7J0q7yeDhBprHuJal/KV9KyKG+Zy3bmQIxNwkPh0KMP5r1YMTKlyifwbWK0JitRCSa0Fa6z6+TgJi193yiR5S1MQ+esoQT0RzyIOBl9/GuJmXx/1rXnqrTxmL7UxtqKuM29/eHwF0QDUI=",
+      sig.signatureValue,
       "wrong signature value")
 
     test.equal(sig.keyInfo, "<KeyInfo><dummyKey>1234</dummyKey></KeyInfo>", "keyInfo caluse not correctly loaded")
@@ -403,32 +403,32 @@ module.exports = {
 
     var digests = ["b5GCZ2xpP5T7tbLWBTkOl4CYupQ=", "K4dI497ZCxzweDIrbndUSmtoezY=", "sH1gxKve8wlU8LlFVa2l6w3HMJ0="]
 
-    
-    for (var i=0; i<sig.references.length; i++) {      
-      var ref = sig.references[i]    
+
+    for (var i=0; i<sig.references.length; i++) {
+      var ref = sig.references[i]
       var expectedUri = "#_"+i
       test.equal(expectedUri, ref.uri, "wrong uri for index " + i + ". expected: " + expectedUri + " actual: " + ref.uri)
       test.equal(1, ref.transforms.length)
       test.equal("http://www.w3.org/2001/10/xml-exc-c14n#", ref.transforms[0])
       test.equal(digests[i], ref.digestValue)
-      test.equal("http://www.w3.org/2000/09/xmldsig#sha1", ref.digestAlgorithm)      
-    }    
+      test.equal("http://www.w3.org/2000/09/xmldsig#sha1", ref.digestAlgorithm)
+    }
 
     test.done()
-  },  
- 
+  },
+
   "verify valid signature": function(test) {
-    passValidSignature(test, "./test/static/valid_signature.xml")   
+    passValidSignature(test, "./test/static/valid_signature.xml")
     passValidSignature(test, "./test/static/valid_signature wsu.xml", "wssecurity")
-    passValidSignature(test, "./test/static/valid_signature_with_reference_keyInfo.xml")   
-    passValidSignature(test, "./test/static/valid_signature_utf8.xml")   
-    test.done() 
+    passValidSignature(test, "./test/static/valid_signature_with_reference_keyInfo.xml")
+    passValidSignature(test, "./test/static/valid_signature_utf8.xml")
+    test.done()
   },
 
 
   "fail invalid signature": function(test) {
     failInvalidSignature(test, "./test/static/invalid_signature - signature value.xml")
-    failInvalidSignature(test, "./test/static/invalid_signature - hash.xml")    
+    failInvalidSignature(test, "./test/static/invalid_signature - hash.xml")
     failInvalidSignature(test, "./test/static/invalid_signature - non existing reference.xml")
     failInvalidSignature(test, "./test/static/invalid_signature - changed content.xml")
     failInvalidSignature(test, "./test/static/invalid_signature - wsu - invalid signature value.xml", "wssecurity")
@@ -438,7 +438,7 @@ module.exports = {
 
     test.done()
   },
- 
+
 
   "allow empty reference uri when signing": function(test) {
     var xml = "<root><x /></root>"
@@ -446,12 +446,12 @@ module.exports = {
     sig.signingKey = fs.readFileSync("./test/static/client.pem")
     sig.keyInfoProvider = null
 
-    sig.addReference("//*[local-name(.)='root']", ["http://www.w3.org/2000/09/xmldsig#enveloped-signature"], "http://www.w3.org/2000/09/xmldsig#sha1", "", "", "", true)  
+    sig.addReference("//*[local-name(.)='root']", ["http://www.w3.org/2000/09/xmldsig#enveloped-signature"], "http://www.w3.org/2000/09/xmldsig#sha1", "", "", "", true)
 
     sig.computeSignature(xml)
-    var signedXml = sig.getSignedXml()    
-    var doc = new dom().parseFromString(signedXml)    
-    var URI = select(doc, "//*[local-name(.)='Reference']/@URI")[0]            
+    var signedXml = sig.getSignedXml()
+    var doc = new dom().parseFromString(signedXml)
+    var URI = select(doc, "//*[local-name(.)='Reference']/@URI")[0]
     test.equal(URI.value, "", "uri should be empty but instead was " + URI.value)
     test.done()
   }
@@ -468,15 +468,15 @@ function passValidSignature(test, file, mode) {
 function failInvalidSignature(test, file, mode) {
   var xml = fs.readFileSync(file).toString()
   var res = verifySignature(xml, mode)
-  test.equal(false, res, "expected signature to be invalid, but it was reported valid")  
+  test.equal(false, res, "expected signature to be invalid, but it was reported valid")
 }
 
 function verifySignature(xml, mode) {
-   
-  var doc = new dom().parseFromString(xml)    
+
+  var doc = new dom().parseFromString(xml)
   var node = select(doc, "/*/*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")[0]
-  
-  var sig = new SignedXml(mode) 
+
+  var sig = new SignedXml(mode)
   sig.keyInfoProvider = new FileKeyInfo("./test/static/client_public.pem")
   sig.loadSignature(node.toString())
   var res = sig.checkSignature(xml)
@@ -491,7 +491,7 @@ function verifyDoesNotDuplicateIdAttributes(test, mode, prefix) {
   sig.addReference("//*[local-name(.)='x']")
   sig.computeSignature(xml)
   var signedxml = sig.getOriginalXmlWithIds()
-  var doc = new dom().parseFromString(signedxml)    
+  var doc = new dom().parseFromString(signedxml)
   var attrs = select(doc, "//@*")
   test.equals(2, attrs.length, "wrong nuber of attributes")
 
@@ -518,10 +518,10 @@ function verifyAddsId(test, mode, nsMode) {
   nodeExists(test, doc, xpath.replace("{id}", "0").replace("{elem}", "x"))
   nodeExists(test, doc, xpath.replace("{id}", "1").replace("{elem}", "y"))
   nodeExists(test, doc, xpath.replace("{id}", "2").replace("{elem}", "w"))
- 
+
 }
 
-function nodeExists(test, doc, xpath) {  
+function nodeExists(test, doc, xpath) {
   if (!doc && !xpath) return
   var node = select(doc, xpath)
   test.ok(node.length==1, "xpath " + xpath + " not found")


### PR DESCRIPTION
this PR adds the following features:

- `computeSignature` now accepts a options object for specify **location, prefix and custom attributes** for the signature

- Ability to add **custom attributes** to the generated signature

My use case is generate something like the following document ->

![image](https://cloud.githubusercontent.com/assets/4262050/7899805/990bba1a-06f8-11e5-8c2f-36ff2b98c10e.png)

with this: 

```js
signer.computeSignature(xml, {
 prefix: 'ds',
 attrs: {
   Id: 'signatureKG'
   // ... more attrs here ..
 }
});
```

- Ability to **specify the location of the signature based on a reference node** (defaults to append the signature in the root node)

For example, this code signs the `<repository>` node and adds the signature **after** the `<name>` node
```js
var xml = "<root><name>xml-crypto</name><repository>github</repository></root>"
var sig = new SignedXml()

sig.signingKey = fs.readFileSync("path/to/key")
sig.addReference("//*[local-name(.)='repository']")

sig.computeSignature(xml, {
  location: {
    reference: '/root/name', // xpath expression
    action: 'after'
  }
});
```

The following actions are supported: `append, prepend, before, after`.

Let me know if you see any problems with this PR