### PR TITLE
Switch loadSignature to accept string or XML node

### DIFF
--- a/lib/signed-xml.js
+++ b/lib/signed-xml.js
@@ -179,7 +179,7 @@ function SignedXml(idMode, options) {
   this.canonicalizationAlgorithm = "http://www.w3.org/2001/10/xml-exc-c14n#"
   this.signedXml = ""
   this.signatureXml = ""
-  this.signatureXmlDoc = null
+  this.signatureNode = null
   this.signatureValue = ""
   this.originalXmlWithIds = ""
   this.validationErrors = []
@@ -230,7 +230,7 @@ SignedXml.prototype.checkSignature = function(xml) {
 }
 
 SignedXml.prototype.validateSignatureValue = function() {
-  var signedInfo = utils.findChilds(this.signatureXmlDoc.documentElement, "SignedInfo")
+  var signedInfo = utils.findChilds(this.signatureNode, "SignedInfo")
   if (signedInfo.length==0) throw new Error("could not find SignedInfo element in the message")
   var signedInfoCanon = this.getCanonXml([this.canonicalizationAlgorithm], signedInfo[0])
   var signer = this.findSignatureAlgorithm(this.signatureAlgorithm)
@@ -301,21 +301,24 @@ SignedXml.prototype.validateReferences = function(doc) {
   return true
 }
 
-SignedXml.prototype.loadSignature = function(signatureXml) {
-  this.signatureXml = signatureXml
+SignedXml.prototype.loadSignature = function(signatureNode) {
+  if (typeof signatureNode === 'string') {
+    this.signatureNode = signatureNode = new Dom().parseFromString(signatureNode);
+  } else {
+    this.signatureNode = signatureNode;
+  }
 
-  var doc = new Dom().parseFromString(signatureXml)
-  this.signatureXmlDoc = doc
+  this.signatureXml = signatureNode.toString();
 
-  var nodes = select(doc, "//*[local-name(.)='CanonicalizationMethod']/@Algorithm")
+  var nodes = select(signatureNode, ".//*[local-name(.)='CanonicalizationMethod']/@Algorithm")
   if (nodes.length==0) throw new Error("could not find CanonicalizationMethod/@Algorithm element")
   this.canonicalizationAlgorithm = nodes[0].value
 
   this.signatureAlgorithm =
-    utils.findFirst(doc, "//*[local-name(.)='SignatureMethod']/@Algorithm").value
+    utils.findFirst(signatureNode, ".//*[local-name(.)='SignatureMethod']/@Algorithm").value
 
   this.references = []
-  var references = select(doc, "//*[local-name(.)='SignedInfo']/*[local-name(.)='Reference']")
+  var references = select(signatureNode, ".//*[local-name(.)='SignedInfo']/*[local-name(.)='Reference']")
   if (references.length == 0) throw new Error("could not find any Reference elements")
 
   for (var i in references) {
@@ -325,9 +328,9 @@ SignedXml.prototype.loadSignature = function(signatureXml) {
   }
 
   this.signatureValue =
-    utils.findFirst(doc, "//*[local-name(.)='SignatureValue']/text()").data.replace(/\n/g, '')
+    utils.findFirst(signatureNode, ".//*[local-name(.)='SignatureValue']/text()").data.replace(/\n/g, '')
 
-  this.keyInfo = select(doc, "//*[local-name(.)='KeyInfo']")
+  this.keyInfo = select(signatureNode, ".//*[local-name(.)='KeyInfo']")
 }
 
 /**

--- a/test/saml-response-test.js
+++ b/test/saml-response-test.js
@@ -8,7 +8,7 @@ exports['test validating SAML response'] = function (test) {
   var signature = crypto.xpath(doc, "/*/*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")[0];
   var sig = new crypto.SignedXml();
   sig.keyInfoProvider = new crypto.FileKeyInfo("./test/static/feide_public.pem");
-  sig.loadSignature(signature.toString());
+  sig.loadSignature(signature);
   var result = sig.checkSignature(xml);
   test.equal(result, true);
   test.done();
@@ -20,7 +20,7 @@ exports['test validating SAML response where a namespace is defined outside the 
   var signature = crypto.xpath(doc, "//*//*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")[0];
   var sig = new crypto.SignedXml();
   sig.keyInfoProvider = new crypto.FileKeyInfo("./test/static/saml_external_ns.pem");
-  sig.loadSignature(signature.toString());
+  sig.loadSignature(signature);
   var result = sig.checkSignature(xml);
   test.equal(result, true);
   test.done();
@@ -32,7 +32,7 @@ exports['test validating SAML response WithComments'] = function (test) {
   var signature = crypto.xpath(doc, "/*/*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")[0];
   var sig = new crypto.SignedXml();
   sig.keyInfoProvider = new crypto.FileKeyInfo("./test/static/feide_public.pem");
-  sig.loadSignature(signature.toString());
+  sig.loadSignature(signature);
   var result = sig.checkSignature(xml);
   // This doesn't matter, just want to make sure that we don't fail due to unknown algorithm
   test.equal(result, false);

--- a/test/signature-integration-tests.js
+++ b/test/signature-integration-tests.js
@@ -55,7 +55,7 @@ module.exports = {
     var signature = crypto.xpath(doc, "//*//*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")[0];
     var sig = new crypto.SignedXml();
     sig.keyInfoProvider = new crypto.FileKeyInfo("./test/static/empty_uri.pem");
-    sig.loadSignature(signature.toString());    
+    sig.loadSignature(signature);    
     var result = sig.checkSignature(sampleXml);
     test.equal(result, true);
     test.done();
@@ -79,7 +79,7 @@ module.exports = {
     var signature = crypto.xpath(doc, "//*//*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")[0];
     var sig = new crypto.SignedXml();    
     sig.keyInfoProvider = new crypto.FileKeyInfo("./test/static/windows_store_certificate.pem");
-    sig.loadSignature(signature.toString());    
+    sig.loadSignature(signature);    
     var result = sig.checkSignature(xml);
     test.equal(result, true);
     test.done();
@@ -96,7 +96,7 @@ module.exports = {
     var signature = crypto.xpath(doc, "//*//*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")[0];
     var sig = new crypto.SignedXml();    
     sig.keyInfoProvider = new crypto.FileKeyInfo("./test/static/signature_with_inclusivenamespaces.pem");
-    sig.loadSignature(signature.toString());    
+    sig.loadSignature(signature);    
     var result = sig.checkSignature(xml);
     test.equal(result, true);
     test.done();

--- a/test/signature-unit-tests.js
+++ b/test/signature-unit-tests.js
@@ -476,6 +476,7 @@ module.exports = {
 
   "correctly loads signature": function(test) {
     passLoadSignature(test, "./test/static/valid_signature.xml");
+    passLoadSignature(test, "./test/static/valid_signature.xml", true);
     passLoadSignature(test, "./test/static/valid_signature_with_root_level_sig_namespace.xml");
     test.done()
   },
@@ -525,12 +526,12 @@ function passValidSignature(test, file, mode) {
   test.equal(true, res, "expected signature to be valid, but it was reported invalid")
 }
 
-function passLoadSignature(test, file) {
+function passLoadSignature(test, file, toString) {
   var xml = fs.readFileSync(file).toString()
   var doc = new dom().parseFromString(xml)
   var node = select(doc, "/*//*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")[0]
   var sig = new SignedXml()
-  sig.loadSignature(node.toString())
+  sig.loadSignature(toString ? node.toString() : node)
 
   test.equal("http://www.w3.org/2001/10/xml-exc-c14n#",
     sig.canonicalizationAlgorithm,
@@ -576,7 +577,7 @@ function verifySignature(xml, mode) {
 
   var sig = new SignedXml(mode)
   sig.keyInfoProvider = new FileKeyInfo("./test/static/client_public.pem")
-  sig.loadSignature(node.toString())
+  sig.loadSignature(node)
   var res = sig.checkSignature(xml)
   console.log(sig.validationErrors)
   return res;


### PR DESCRIPTION
@bjrmatos @yaronn Here is what I was referring to in #59. This allows `loadSignature` to accept a DOM node or XML string, keeping backwards compatibility. The only possible breaking change would be if a caller was using `signatureXmlDoc` but I would think that should be regarded as private.

Thoughts?