### PR TITLE
signature validation fails if node passed to loadSignature is a Document

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -18,6 +18,7 @@ function findFirst(doc, xpath) {
 }
 
 function findChilds(node, localName, namespace) {
+  node = node.documentElement || node;
   var res = []
   for (var i = 0; i<node.childNodes.length; i++) {
     var child = node.childNodes[i]       

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
         "type" :  "MIT License",
         "url" :   "http://www.opensource.org/licenses/mit-license.php" }],
     "scripts":    {
-        "test": "nodeunit ./test/canonicalization-unit-tests.js ./test/c14nWithComments-unit-tests.js ./test/signature-unit-tests.js ./test/saml-response-test.js ./test/signature-integration-tests.js"
+        "test": "nodeunit ./test/canonicalization-unit-tests.js ./test/c14nWithComments-unit-tests.js ./test/signature-unit-tests.js ./test/saml-response-test.js ./test/signature-integration-tests.js ./test/document-test.js"
     }
 }

--- a/test/document-test.js
+++ b/test/document-test.js
@@ -1,0 +1,16 @@
+var crypto = require('../index');
+var xmldom = require('xmldom');
+var fs = require('fs');
+
+exports['test with a document '] = function (test) {
+  var xml = fs.readFileSync('./test/static/valid_saml.xml', 'utf-8');
+  var doc = new xmldom.DOMParser().parseFromString(xml);
+  var signature = new xmldom.DOMParser().parseFromString(crypto.xpath(doc, "/*/*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")[0].toString());
+  var sig = new crypto.SignedXml();
+  sig.keyInfoProvider = new crypto.FileKeyInfo("./test/static/feide_public.pem");
+  sig.loadSignature(signature);
+  var result = sig.checkSignature(xml);
+  test.equal(result, true);
+  test.done();
+};
+


### PR DESCRIPTION
Includes a test that fails before the change in util.js is applied

example/example.js fails when run without this change