### PR TITLE
Add support for REC-xml-c14n-20010315

### DIFF
--- a/lib/signed-xml.js
+++ b/lib/signed-xml.js
@@ -224,6 +224,7 @@ function SignedXml(idMode, options) {
 
 SignedXml.CanonicalizationAlgorithms = {
   'http://www.w3.org/2001/10/xml-exc-c14n#': ExclusiveCanonicalization,
+  'http://www.w3.org/TR/2001/REC-xml-c14n-20010315': ExclusiveCanonicalization,
   'http://www.w3.org/2001/10/xml-exc-c14n#WithComments': ExclusiveCanonicalizationWithComments,
   'http://www.w3.org/2000/09/xmldsig#enveloped-signature': EnvelopedSignature
 }


### PR DESCRIPTION
This algorithm used in new MS purchase certificates. But ExclusiveCanonicalization can check signature of it.