### PR TITLE
Update exclusive-canonicalization.js

### DIFF
--- a/lib/exclusive-canonicalization.js
+++ b/lib/exclusive-canonicalization.js
@@ -101,7 +101,7 @@ ExclusiveCanonicalization.prototype.renderNs = function(node, prefixesInScope, d
 
       //handle all prefixed attributes that are not xmlns definitions and where
       //the prefix is not defined already
-      if (attr.prefix && prefixesInScope.indexOf(attr.prefix)==-1 && attr.prefix!="xmlns") {
+      if (attr.prefix && prefixesInScope.indexOf(attr.prefix)==-1 && attr.prefix!="xmlns" && attr.prefix!="xml") {
         nsListToRender.push({"prefix": attr.prefix, "namespaceURI": attr.namespaceURI});
         prefixesInScope.push(attr.prefix);
       }


### PR DESCRIPTION
Fix for #95. The default namespace should not be rendered explicitly.