### PR TITLE
Canonicalization of line separators

### DIFF
--- a/lib/signed-xml.js
+++ b/lib/signed-xml.js
@@ -368,7 +368,7 @@ SignedXml.prototype.loadSignature = function(signatureNode) {
   }
 
   this.signatureValue =
-    utils.findFirst(signatureNode, ".//*[local-name(.)='SignatureValue']/text()").data.replace(/\n/g, '')
+    utils.findFirst(signatureNode, ".//*[local-name(.)='SignatureValue']/text()").data.replace(/\r?\n/g, '')
 
   this.keyInfo = select(signatureNode, ".//*[local-name(.)='KeyInfo']")
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -54,9 +54,13 @@ var escaped_one_to_xml_special_map = {
 }
  
 function normalizeXmlIncludingCR(string) {
-    return string.replace(/([\&"<>\r])/g, function(str, item) {
-        return xml_special_to_escaped_one_map[item];
-    })
+  // replace \r\n lines with \n
+  // See https://www.w3.org/TR/2000/WD-xml-c14n-20000119.html#charescaping
+  // and https://www.w3.org/TR/2001/REC-xml-c14n-20010315#Examples
+  return string.replace(/(\r?\n)+/g, '\n')
+    .replace(/([\&"<>\r])/g, function(str, item) {
+      return xml_special_to_escaped_one_map[item];
+  })
 }
  
 function deNormalizeXmlIncludingCR(string) {

--- a/test/canonicalization-unit-tests.js
+++ b/test/canonicalization-unit-tests.js
@@ -204,6 +204,30 @@ module.exports = {
   },
 
 
+  "Exclusive canonicalization turns CR-NL (windows line separator) to single NL between elements": function (test) {
+    compare(test,
+      "<root><child><inner>123</inner>\r\n</child></root>",
+      "//*[local-name(.)='child']",
+      "<child><inner>123</inner>\n</child>")
+  },
+
+
+  "Exclusive canonicalization turns multiple line break into a single NL between elements": function (test) {
+    compare(test,
+      "<root><child><inner>123</inner>\r\n\n\n\r\n</child></root>",
+      "//*[local-name(.)='child']",
+      "<child><inner>123</inner>\n</child>")
+  },
+
+
+  "Exclusive canonicalization preserves CR-NL (windows line separator) in values": function (test) {
+    compare(test,
+      "<root><child><inner>\r\n12\r\n3\r\n</inner></child></root>",
+      "//*[local-name(.)='child']",
+      "<child><inner>\n12\n3\n</inner></child>")
+  },
+
+
   "Exclusive canonicalization turns empty element to start-end tag pairs": function (test) {
     compare(test,
       "<root><child><inner /></child></root>",

--- a/test/signature-integration-tests.js
+++ b/test/signature-integration-tests.js
@@ -104,6 +104,40 @@ module.exports = {
 
 
 
+  "signature with inclusive namespaces with unix line separators": function(test) {
+
+    var xml = fs.readFileSync('./test/static/signature_with_inclusivenamespaces_lines.xml', 'utf-8');
+    var doc = new Dom().parseFromString(xml);
+    xml = doc.firstChild.toString()
+
+    var signature = crypto.xpath(doc, "//*//*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")[0];
+    var sig = new crypto.SignedXml();
+    sig.keyInfoProvider = new crypto.FileKeyInfo("./test/static/signature_with_inclusivenamespaces.pem");
+    sig.loadSignature(signature);
+    var result = sig.checkSignature(xml);
+    test.equal(result, true);
+    test.done();
+  },
+
+
+
+  "signature with inclusive namespaces with windows line separators": function(test) {
+
+    var xml = fs.readFileSync('./test/static/signature_with_inclusivenamespaces_lines_windows.xml', 'utf-8');
+    var doc = new Dom().parseFromString(xml);
+    xml = doc.firstChild.toString()
+
+    var signature = crypto.xpath(doc, "//*//*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")[0];
+    var sig = new crypto.SignedXml();
+    sig.keyInfoProvider = new crypto.FileKeyInfo("./test/static/signature_with_inclusivenamespaces.pem");
+    sig.loadSignature(signature);
+    var result = sig.checkSignature(xml);
+    test.equal(result, true);
+    test.done();
+  },
+
+
+
 
   "should create single root xml document when signing inner node": function(test) {
     var xml = "<library>" +

--- a/test/static/signature_with_inclusivenamespaces_lines.xml
+++ b/test/static/signature_with_inclusivenamespaces_lines.xml
@@ -1,0 +1,20 @@
+<saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion" ID="id8132302868541019755414121" IssueInstant="2013-08-03T21:54:43.942Z" Version="2.0" xmlns:xs="http://www.w3.org/2001/XMLSchema"><saml2:Issuer Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity" xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">http://www.okta.com/k7xkhq0jUHUPQAXVMUAN</saml2:Issuer><ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:SignedInfo><ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/><ds:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/><ds:Reference URI="#id8132302868541019755414121"><ds:Transforms><ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/><ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"><ec:InclusiveNamespaces xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#" PrefixList="xs"/></ds:Transform></ds:Transforms><ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/><ds:DigestValue>4G+uveKmtiB1EkY5BAt+8lmQwjI=</ds:DigestValue></ds:Reference></ds:SignedInfo>
+<ds:SignatureValue>
+Q80N6FUr5/YPtEzRlRdMoPu+bL0MssDxNUY+yxykzbmxsI0joEo/SmmSgZrDYQKTllZk/KfzBMPF
+V9yBH4+mEzCU5E3xuCs99jZzafcw3K8mIMTJy1YHxjc359d27R5s50i9w5PHsusRov0MjQIoJ2w4
+8Gy4EnYaViqBR3UVEqE=
+</ds:SignatureValue>
+<ds:KeyInfo><ds:X509Data><ds:X509Certificate>
+MIICnTCCAgagAwIBAgIGAUBGHxqUMA0GCSqGSIb3DQEBBQUAMIGRMQswCQYDVQQGEwJVUzETMBEG
+A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
+MBIGA1UECwwLU1NPUHJvdmlkZXIxEjAQBgNVBAMMCWtsdWdsYWJzMjEcMBoGCSqGSIb3DQEJARYN
+aW5mb0Bva3RhLmNvbTAeFw0xMzA4MDMyMTM4MzhaFw00MzA4MDMyMTM5MzhaMIGRMQswCQYDVQQG
+EwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UE
+CgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxEjAQBgNVBAMMCWtsdWdsYWJzMjEcMBoGCSqG
+SIb3DQEJARYNaW5mb0Bva3RhLmNvbTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAsCB9lJTH
+qB7vdM5jeOH84cW8u7IHYv4/OAPYF0fBYe9wJy19CgyM2OgiASuAcItnH4WhB+io2ZPwb/Xwl7Uu
+4XmUE0l+mkCNuDYp5fXTZxwv5G6HvkAxXZio0Rk9T0VETCroxgpS5LxQ/o/owjR39S7xzRnj6ddX
+3Mq2yGjKyBcCAwEAATANBgkqhkiG9w0BAQUFAAOBgQAB1qGNqSNLLWq+RPcP+wOaWtYpJOJ8/MbZ
+EWWm9/KKHKXM6J/zgUUIXZi3czMeO+Y+X14PR8lGXoAHf5b/JavG9FmFvRn4fGa45VTVo2GfMN6K
+aIKF0obeCbYi/QUf8B+Xi1tSIJm1VCKRE7nnliQ/TzGaNulgWeyTbVkG0/X8LQ==</ds:X509Certificate></ds:X509Data></ds:KeyInfo>
+</ds:Signature><saml2:Subject xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"><saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">admin@kluglabs.com</saml2:NameID><saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"><saml2:SubjectConfirmationData NotOnOrAfter="2013-08-03T21:59:43.942Z" Recipient="https://auth0145.auth0.com"/></saml2:SubjectConfirmation></saml2:Subject><saml2:Conditions NotBefore="2013-08-03T21:49:43.943Z" NotOnOrAfter="2013-08-03T21:59:43.942Z" xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"><saml2:AudienceRestriction><saml2:Audience>https://auth0145.auth0.com</saml2:Audience></saml2:AudienceRestriction></saml2:Conditions><saml2:AuthnStatement AuthnInstant="2013-08-03T21:54:43.942Z" SessionIndex="id1375566883942.687610437" xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"><saml2:AuthnContext><saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml2:AuthnContextClassRef></saml2:AuthnContext></saml2:AuthnStatement><saml2:AttributeStatement xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"><saml2:Attribute Name="Role" NameFormat="ns"><saml2:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:string">Admin</saml2:AttributeValue></saml2:Attribute></saml2:AttributeStatement></saml2:Assertion>

--- a/test/static/signature_with_inclusivenamespaces_lines_windows.xml
+++ b/test/static/signature_with_inclusivenamespaces_lines_windows.xml
@@ -1,0 +1,20 @@
+<saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion" ID="id8132302868541019755414121" IssueInstant="2013-08-03T21:54:43.942Z" Version="2.0" xmlns:xs="http://www.w3.org/2001/XMLSchema"><saml2:Issuer Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity" xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">http://www.okta.com/k7xkhq0jUHUPQAXVMUAN</saml2:Issuer><ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:SignedInfo><ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/><ds:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/><ds:Reference URI="#id8132302868541019755414121"><ds:Transforms><ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/><ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"><ec:InclusiveNamespaces xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#" PrefixList="xs"/></ds:Transform></ds:Transforms><ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/><ds:DigestValue>4G+uveKmtiB1EkY5BAt+8lmQwjI=</ds:DigestValue></ds:Reference></ds:SignedInfo>
+<ds:SignatureValue>
+Q80N6FUr5/YPtEzRlRdMoPu+bL0MssDxNUY+yxykzbmxsI0joEo/SmmSgZrDYQKTllZk/KfzBMPF
+V9yBH4+mEzCU5E3xuCs99jZzafcw3K8mIMTJy1YHxjc359d27R5s50i9w5PHsusRov0MjQIoJ2w4
+8Gy4EnYaViqBR3UVEqE=
+</ds:SignatureValue>
+<ds:KeyInfo><ds:X509Data><ds:X509Certificate>
+MIICnTCCAgagAwIBAgIGAUBGHxqUMA0GCSqGSIb3DQEBBQUAMIGRMQswCQYDVQQGEwJVUzETMBEG
+A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
+MBIGA1UECwwLU1NPUHJvdmlkZXIxEjAQBgNVBAMMCWtsdWdsYWJzMjEcMBoGCSqGSIb3DQEJARYN
+aW5mb0Bva3RhLmNvbTAeFw0xMzA4MDMyMTM4MzhaFw00MzA4MDMyMTM5MzhaMIGRMQswCQYDVQQG
+EwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UE
+CgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxEjAQBgNVBAMMCWtsdWdsYWJzMjEcMBoGCSqG
+SIb3DQEJARYNaW5mb0Bva3RhLmNvbTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAsCB9lJTH
+qB7vdM5jeOH84cW8u7IHYv4/OAPYF0fBYe9wJy19CgyM2OgiASuAcItnH4WhB+io2ZPwb/Xwl7Uu
+4XmUE0l+mkCNuDYp5fXTZxwv5G6HvkAxXZio0Rk9T0VETCroxgpS5LxQ/o/owjR39S7xzRnj6ddX
+3Mq2yGjKyBcCAwEAATANBgkqhkiG9w0BAQUFAAOBgQAB1qGNqSNLLWq+RPcP+wOaWtYpJOJ8/MbZ
+EWWm9/KKHKXM6J/zgUUIXZi3czMeO+Y+X14PR8lGXoAHf5b/JavG9FmFvRn4fGa45VTVo2GfMN6K
+aIKF0obeCbYi/QUf8B+Xi1tSIJm1VCKRE7nnliQ/TzGaNulgWeyTbVkG0/X8LQ==</ds:X509Certificate></ds:X509Data></ds:KeyInfo>
+</ds:Signature><saml2:Subject xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"><saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">admin@kluglabs.com</saml2:NameID><saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"><saml2:SubjectConfirmationData NotOnOrAfter="2013-08-03T21:59:43.942Z" Recipient="https://auth0145.auth0.com"/></saml2:SubjectConfirmation></saml2:Subject><saml2:Conditions NotBefore="2013-08-03T21:49:43.943Z" NotOnOrAfter="2013-08-03T21:59:43.942Z" xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"><saml2:AudienceRestriction><saml2:Audience>https://auth0145.auth0.com</saml2:Audience></saml2:AudienceRestriction></saml2:Conditions><saml2:AuthnStatement AuthnInstant="2013-08-03T21:54:43.942Z" SessionIndex="id1375566883942.687610437" xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"><saml2:AuthnContext><saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml2:AuthnContextClassRef></saml2:AuthnContext></saml2:AuthnStatement><saml2:AttributeStatement xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"><saml2:Attribute Name="Role" NameFormat="ns"><saml2:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:string">Admin</saml2:AttributeValue></saml2:Attribute></saml2:AttributeStatement></saml2:Assertion>


### PR DESCRIPTION
Convert `\r\n` new lines to canonical form: `\n`.
Convert multiple new lines to a single one.

Fixes #65 & probably #43.