### PR TITLE
Fixed normalization of special characters according to spec

### DIFF
--- a/lib/exclusive-canonicalization.js
+++ b/lib/exclusive-canonicalization.js
@@ -50,7 +50,7 @@ ExclusiveCanonicalization.prototype.renderAttrs = function(node, defaultNS) {
     if (!attrListToRender.hasOwnProperty(a)) { continue; }
 
     attr = attrListToRender[a];
-    res.push(" ", attr.name, '="', utils.normalizeXmlIncludingCR(attr.value), '"');
+    res.push(" ", attr.name, '="', utils.encodeSpecialCharactersInAttribute(attr.value), '"');
   }
 
   return res.join("");
@@ -124,7 +124,7 @@ ExclusiveCanonicalization.prototype.renderNs = function(node, prefixesInScope, d
 ExclusiveCanonicalization.prototype.processInner = function(node, prefixesInScope, defaultNs, defaultNsForPrefix, inclusiveNamespacesPrefixList) {
 
   if (node.nodeType === 8) { return this.renderComment(node); }
-  if (node.data) { return utils.normalizeXmlIncludingCR(node.data); }
+  if (node.data) { return utils.encodeSpecialCharactersInText(node.data); }
 
   var i, pfxCopy
     , ns = this.renderNs(node, prefixesInScope, defaultNs, defaultNsForPrefix, inclusiveNamespacesPrefixList)
@@ -171,7 +171,7 @@ ExclusiveCanonicalization.prototype.renderComment = function (node) {
     }
   }
 
-  return (isAfterDocument ? "\n" : "") + "<!--" + utils.normalizeXmlIncludingCR(node.data) + "-->" + (isBeforeDocument ? "\n" : "");
+  return (isAfterDocument ? "\n" : "") + "<!--" + utils.encodeSpecialCharactersInText(node.data) + "-->" + (isBeforeDocument ? "\n" : "");
 };
 
 /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -81,12 +81,8 @@ function normalizeTextWhitespace(text){
 
 function normalizeAttributeValueWhitespace(attributeValue){
     // Note: this should normally be done by the xml parser. See:
-    // - https://www.w3.org/TR/xml/#sec-line-ends
     // - https://www.w3.org/TR/xml/#AVNormalize
-    return attributeValue
-        .replace(/\r\n?/g, '\n')
-        .replace(/[\r\n\t]/g, ' ')
-        .replace(/ +/g, ' ')
+    return attributeValue.replace(/[\r\n\t ]+/g, ' ')
 }
 
 exports.findAttr = findAttr

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -54,36 +54,27 @@ var xml_special_to_encoded_text = {
 }
 
 function encodeSpecialCharactersInAttribute(attributeValue){
-    attributeValue = normalizeAttributeValueWhitespace(attributeValue);
-    return attributeValue.replace(/([&<"\r\n\t])/g, function(str, item){
-        // See:
-        // - https://www.w3.org/TR/xml-c14n#ProcessingModel (Attribute Nodes)
-        // - https://www.w3.org/TR/xml-c14n#Example-Chars
-        return xml_special_to_encoded_attribute[item]
-    })
+    return attributeValue
+        .replace(/[\r\n\t ]+/g, ' ') // White space normalization (Note: this should normally be done by the xml parser) See: https://www.w3.org/TR/xml/#AVNormalize
+        .replace(/([&<"\r\n\t])/g, function(str, item){
+            // Special character normalization. See:
+            // - https://www.w3.org/TR/xml-c14n#ProcessingModel (Attribute Nodes)
+            // - https://www.w3.org/TR/xml-c14n#Example-Chars
+            return xml_special_to_encoded_attribute[item]
+        })
 }
 
 function encodeSpecialCharactersInText(text){
-    text = normalizeTextWhitespace(text);
-    return text.replace(/([&<>\r])/g, function(str, item){
-        // See:
-        // - https://www.w3.org/TR/xml-c14n#ProcessingModel (Text Nodes)
-        // - https://www.w3.org/TR/xml-c14n#Example-Chars
-        return xml_special_to_encoded_text[item]
-    })
+    return text
+        .replace(/\r\n?/g, '\n')  // Line ending normalization (Note: this should normally be done by the xml parser). See: https://www.w3.org/TR/xml/#sec-line-ends
+        .replace(/([&<>\r])/g, function(str, item){
+            // Special character normalization. See:
+            // - https://www.w3.org/TR/xml-c14n#ProcessingModel (Text Nodes)
+            // - https://www.w3.org/TR/xml-c14n#Example-Chars
+            return xml_special_to_encoded_text[item]
+        })
 }
 
-function normalizeTextWhitespace(text){
-    // Note: this should normally be done by the xml parser. See:
-    // - https://www.w3.org/TR/xml/#sec-line-ends
-    return text.replace(/\r\n?/g, '\n')
-}
-
-function normalizeAttributeValueWhitespace(attributeValue){
-    // Note: this should normally be done by the xml parser. See:
-    // - https://www.w3.org/TR/xml/#AVNormalize
-    return attributeValue.replace(/[\r\n\t ]+/g, ' ')
-}
 
 exports.findAttr = findAttr
 exports.findChilds = findChilds

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -37,41 +37,40 @@ function attrEqualsImplicitly(attr, localName, namespace, node) {
 	return attr.localName==localName && ((!attr.namespaceURI && node.namespaceURI==namespace) || !namespace)
 }
 
-var xml_special_to_escaped_one_map = {
+var xml_special_to_encoded_attribute = {
     '&': '&amp;',
+    '<': '&lt;',
     '"': '&quot;',
+    '\r': '&#xD;',
+    '\n':'&#xA;',
+    '\t': '&#x9;'
+}
+
+var xml_special_to_encoded_text = {
+    '&': '&amp;',
     '<': '&lt;',
     '>': '&gt;',
     '\r': '&#xD;'
 }
- 
-var escaped_one_to_xml_special_map = {
-    '&amp;': '&',
-    '&quot;': '"',
-    '&lt;': '<',
-    '&gt;': '>',
-    '&#xD;': '\r'
-}
- 
-function normalizeXmlIncludingCR(string) {
-  // replace \r\n lines with \n
-  // See https://www.w3.org/TR/2000/WD-xml-c14n-20000119.html#charescaping
-  // and https://www.w3.org/TR/2001/REC-xml-c14n-20010315#Examples
-  return string.replace(/(\r?\n)+/g, '\n')
-    .replace(/([\&"<>\r])/g, function(str, item) {
-      return xml_special_to_escaped_one_map[item];
+
+// See:
+// - https://www.w3.org/TR/xml-c14n#ProcessingModel (Attribute Nodes, Text Nodes)
+// - https://www.w3.org/TR/xml-c14n#Example-Chars
+function encodeSpecialCharactersInAttribute(attributeValue) {
+  return attributeValue.replace(/(\r?\n)+/g, '\n')
+    .replace(/([&<"\r\n\t])/g, function(str, item) {
+      return xml_special_to_encoded_attribute[item];
   })
 }
- 
-function deNormalizeXmlIncludingCR(string) {
-    return string.replace(/(&quot;|&lt;|&gt;|&amp;|&#xD;)/g,
-        function(str, item) {
-            return escaped_one_to_xml_special_map[item];
-    })
+
+function encodeSpecialCharactersInText(text) {
+    return text.replace(/([&<>\r])/g, function(str, item) {
+            return xml_special_to_encoded_text[item];
+        })
 }
 
 exports.findAttr = findAttr
 exports.findChilds = findChilds
-exports.normalizeXmlIncludingCR = normalizeXmlIncludingCR
-exports.deNormalizeXmlIncludingCR = deNormalizeXmlIncludingCR
+exports.encodeSpecialCharactersInAttribute = encodeSpecialCharactersInAttribute
+exports.encodeSpecialCharactersInText = encodeSpecialCharactersInText
 exports.findFirst = findFirst

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -42,7 +42,7 @@ var xml_special_to_encoded_attribute = {
     '<': '&lt;',
     '"': '&quot;',
     '\r': '&#xD;',
-    '\n':'&#xA;',
+    '\n': '&#xA;',
     '\t': '&#x9;'
 }
 
@@ -53,20 +53,40 @@ var xml_special_to_encoded_text = {
     '\r': '&#xD;'
 }
 
-// See:
-// - https://www.w3.org/TR/xml-c14n#ProcessingModel (Attribute Nodes, Text Nodes)
-// - https://www.w3.org/TR/xml-c14n#Example-Chars
-function encodeSpecialCharactersInAttribute(attributeValue) {
-  return attributeValue.replace(/(\r?\n)+/g, '\n')
-    .replace(/([&<"\r\n\t])/g, function(str, item) {
-      return xml_special_to_encoded_attribute[item];
-  })
+function encodeSpecialCharactersInAttribute(attributeValue){
+    attributeValue = normalizeAttributeValueWhitespace(attributeValue);
+    return attributeValue.replace(/([&<"\r\n\t])/g, function(str, item){
+        // See:
+        // - https://www.w3.org/TR/xml-c14n#ProcessingModel (Attribute Nodes)
+        // - https://www.w3.org/TR/xml-c14n#Example-Chars
+        return xml_special_to_encoded_attribute[item]
+    })
 }
 
-function encodeSpecialCharactersInText(text) {
-    return text.replace(/([&<>\r])/g, function(str, item) {
-            return xml_special_to_encoded_text[item];
-        })
+function encodeSpecialCharactersInText(text){
+    text = normalizeTextWhitespace(text);
+    return text.replace(/([&<>\r])/g, function(str, item){
+        // See:
+        // - https://www.w3.org/TR/xml-c14n#ProcessingModel (Text Nodes)
+        // - https://www.w3.org/TR/xml-c14n#Example-Chars
+        return xml_special_to_encoded_text[item]
+    })
+}
+
+function normalizeTextWhitespace(text){
+    // Note: this should normally be done by the xml parser. See:
+    // - https://www.w3.org/TR/xml/#sec-line-ends
+    return text.replace(/\r\n?/g, '\n')
+}
+
+function normalizeAttributeValueWhitespace(attributeValue){
+    // Note: this should normally be done by the xml parser. See:
+    // - https://www.w3.org/TR/xml/#sec-line-ends
+    // - https://www.w3.org/TR/xml/#AVNormalize
+    return attributeValue
+        .replace(/\r\n?/g, '\n')
+        .replace(/[\r\n\t]/g, ' ')
+        .replace(/ +/g, ' ')
 }
 
 exports.findAttr = findAttr

--- a/test/c14nWithComments-unit-tests.js
+++ b/test/c14nWithComments-unit-tests.js
@@ -179,17 +179,17 @@ module.exports = {
 
   "Exclusive canonicalization preserves white space in values": function (test) {
     compare(test, 
-      "<root><child><inner>12\r3\t</inner></child></root>", 
+      "<root><child><inner>12\n3\t</inner></child></root>",
       "//*[local-name(.)='child']", 
-      "<child><inner>12&#xD;3\t</inner></child>")
+      "<child><inner>12\n3\t</inner></child>")
   },
   
 
   "Exclusive canonicalization preserves white space bewteen elements": function (test) {
     compare(test, 
-      "<root><child><inner>123</inner>\r</child></root>", 
+      "<root><child><inner>123</inner>\n</child></root>",
       "//*[local-name(.)='child']", 
-      "<child><inner>123</inner>&#xD;</child>")
+      "<child><inner>123</inner>\n</child>")
   },  
 
 
@@ -339,7 +339,7 @@ module.exports = {
       "  </Body>\r" +
       "</Envelope>",
       "//*[local-name(.)='Body']", 
-      "<Body xmlns=\"http://schemas.xmlsoap.org/soap/envelope/\">&#xD;    <ACORD xmlns=\"http://www.ACORD.org/standards/PC_Surety/ACORD1.10.0/xml/\">&#xD;      <SignonRq>&#xD;        <SessKey></SessKey>&#xD;        <ClientDt></ClientDt>&#xD;        <CustLangPref></CustLangPref>&#xD;        <ClientApp>&#xD;          <Org xmlns:p6=\"http://www.w3.org/2001/XMLSchema-instance\" id=\"wewe\" p6:type=\"AssignedIdentifier\"></Org>&#xD;          <Name></Name>&#xD;          <Version></Version>&#xD;        </ClientApp>&#xD;        <ProxyClient>&#xD;          <Org xmlns:p6=\"http://www.w3.org/2001/XMLSchema-instance\" id=\"erer\" p6:type=\"AssignedIdentifier\"></Org>&#xD;          <Name>ererer</Name>&#xD;          <Version>dfdf</Version>&#xD;        </ProxyClient>&#xD;      </SignonRq>&#xD;      <InsuranceSvcRq>&#xD;        <RqUID></RqUID>&#xD;        <SPName id=\"rter\"></SPName>&#xD;        <QuickHit xmlns=\"urn:com.thehartford.bi.acord-extensions\">&#xD;          <StateProvCd xmlns=\"http://www.ACORD.org/standards/PC_Surety/ACORD1.10.0/xml/\" CodeListRef=\"dfdf\"></StateProvCd>&#xD;        </QuickHit>&#xD;        <WorkCompPolicyQuoteInqRq>&#xD;          <RqUID>erer</RqUID>&#xD;          <TransactionRequestDt id=\"erer\"></TransactionRequestDt>&#xD;          <CurCd></CurCd>&#xD;          <BroadLOBCd id=\"erer\"></BroadLOBCd>&#xD;          <InsuredOrPrincipal>&#xD;            <ItemIdInfo>&#xD;              <AgencyId id=\"3434\"></AgencyId>&#xD;              <OtherIdentifier>&#xD;                <CommercialName id=\"3434\"></CommercialName>&#xD;                <ContractTerm>&#xD;                  <EffectiveDt id=\"3434\"></EffectiveDt>&#xD;                  <StartTime id=\"3434\"></StartTime>&#xD;                </ContractTerm>&#xD;              </OtherIdentifier>&#xD;            </ItemIdInfo>&#xD;          </InsuredOrPrincipal>&#xD;          <InsuredOrPrincipal>&#xD;          </InsuredOrPrincipal>&#xD;          <CommlPolicy>&#xD;            <PolicyNumber id=\"3434\"></PolicyNumber>&#xD;            <LOBCd></LOBCd>&#xD;          </CommlPolicy>&#xD;          <WorkCompLineBusiness>&#xD;            <LOBCd></LOBCd>&#xD;            <WorkCompRateState>&#xD;              <WorkCompLocInfo>&#xD;              </WorkCompLocInfo>&#xD;            </WorkCompRateState>&#xD;          </WorkCompLineBusiness>&#xD;          <RemarkText IdRef=\"\">&#xD;          </RemarkText>&#xD;          <RemarkText IdRef=\"2323\" id=\"3434\">&#xD;          </RemarkText>&#xD;        </WorkCompPolicyQuoteInqRq>&#xD;      </InsuranceSvcRq>&#xD;    </ACORD>&#xD;  </Body>")
+      "<Body xmlns=\"http://schemas.xmlsoap.org/soap/envelope/\">\n    <ACORD xmlns=\"http://www.ACORD.org/standards/PC_Surety/ACORD1.10.0/xml/\">\n      <SignonRq>\n        <SessKey></SessKey>\n        <ClientDt></ClientDt>\n        <CustLangPref></CustLangPref>\n        <ClientApp>\n          <Org xmlns:p6=\"http://www.w3.org/2001/XMLSchema-instance\" id=\"wewe\" p6:type=\"AssignedIdentifier\"></Org>\n          <Name></Name>\n          <Version></Version>\n        </ClientApp>\n        <ProxyClient>\n          <Org xmlns:p6=\"http://www.w3.org/2001/XMLSchema-instance\" id=\"erer\" p6:type=\"AssignedIdentifier\"></Org>\n          <Name>ererer</Name>\n          <Version>dfdf</Version>\n        </ProxyClient>\n      </SignonRq>\n      <InsuranceSvcRq>\n        <RqUID></RqUID>\n        <SPName id=\"rter\"></SPName>\n        <QuickHit xmlns=\"urn:com.thehartford.bi.acord-extensions\">\n          <StateProvCd xmlns=\"http://www.ACORD.org/standards/PC_Surety/ACORD1.10.0/xml/\" CodeListRef=\"dfdf\"></StateProvCd>\n        </QuickHit>\n        <WorkCompPolicyQuoteInqRq>\n          <RqUID>erer</RqUID>\n          <TransactionRequestDt id=\"erer\"></TransactionRequestDt>\n          <CurCd></CurCd>\n          <BroadLOBCd id=\"erer\"></BroadLOBCd>\n          <InsuredOrPrincipal>\n            <ItemIdInfo>\n              <AgencyId id=\"3434\"></AgencyId>\n              <OtherIdentifier>\n                <CommercialName id=\"3434\"></CommercialName>\n                <ContractTerm>\n                  <EffectiveDt id=\"3434\"></EffectiveDt>\n                  <StartTime id=\"3434\"></StartTime>\n                </ContractTerm>\n              </OtherIdentifier>\n            </ItemIdInfo>\n          </InsuredOrPrincipal>\n          <InsuredOrPrincipal>\n          </InsuredOrPrincipal>\n          <CommlPolicy>\n            <PolicyNumber id=\"3434\"></PolicyNumber>\n            <LOBCd></LOBCd>\n          </CommlPolicy>\n          <WorkCompLineBusiness>\n            <LOBCd></LOBCd>\n            <WorkCompRateState>\n              <WorkCompLocInfo>\n              </WorkCompLocInfo>\n            </WorkCompRateState>\n          </WorkCompLineBusiness>\n          <RemarkText IdRef=\"\">\n          </RemarkText>\n          <RemarkText IdRef=\"2323\" id=\"3434\">\n          </RemarkText>\n        </WorkCompPolicyQuoteInqRq>\n      </InsuranceSvcRq>\n    </ACORD>\n  </Body>")
   },
 
   "Multiple Canonicalization with namespace definition outside of signed element": function (test) {

--- a/test/canonicalization-unit-tests.js
+++ b/test/canonicalization-unit-tests.js
@@ -179,14 +179,19 @@ module.exports = {
       "<child xmlns=\"bla\" xmlns:p=\"foo\" p:attr=\"val\"><inner>123</inner></child>")
   },
 
-
-  "Exclusive canonicalization works on xml with attribute and element values with special characters": function (test) {
+  "Exclusive canonicalization works on xml with attribute values with special characters": function (test) {
     compare(test,
-      "<root><child><inner attr=\"&amp;11\">&amp;11</inner></child></root>",
+      "<root><child><inner attrEncoded=\"&amp;&lt;>&quot;&#xA;&#xD;&#x9;11\" attrUnencoded='&<>\"\n\r\t11'>11</inner></child></root>",
       "//*[local-name(.)='child']",
-      "<child><inner attr=\"&amp;11\">&amp;11</inner></child>")
+      "<child><inner attrEncoded=\"&amp;&lt;>&quot;&#xA;&#xD;&#x9;11\" attrUnencoded=\"&amp;&lt;>&quot;&#xA;&#xD;&#x9;11\">11</inner></child>")
   },
 
+  "Exclusive canonicalization works on xml with element values with special characters": function (test) {
+    compare(test,
+        "<root><child><innerEncoded>&amp;&lt;>&quot;&#xD;&#x9;11</innerEncoded><innerUnencoded>&<>\"\r\n\t11\</innerUnencoded></child></root>",
+        "//*[local-name(.)='child']",
+        "<child><innerEncoded>&amp;&lt;&gt;\"&#xD;\t11</innerEncoded><innerUnencoded>&amp;&lt;&gt;\"&#xD;\n\t11</innerUnencoded></child>")
+  },
 
   "Exclusive canonicalization preserves white space in values": function (test) {
     compare(test,
@@ -202,31 +207,6 @@ module.exports = {
       "//*[local-name(.)='child']",
       "<child><inner>123</inner>&#xD;</child>")
   },
-
-
-  "Exclusive canonicalization turns CR-NL (windows line separator) to single NL between elements": function (test) {
-    compare(test,
-      "<root><child><inner>123</inner>\r\n</child></root>",
-      "//*[local-name(.)='child']",
-      "<child><inner>123</inner>\n</child>")
-  },
-
-
-  "Exclusive canonicalization turns multiple line break into a single NL between elements": function (test) {
-    compare(test,
-      "<root><child><inner>123</inner>\r\n\n\n\r\n</child></root>",
-      "//*[local-name(.)='child']",
-      "<child><inner>123</inner>\n</child>")
-  },
-
-
-  "Exclusive canonicalization preserves CR-NL (windows line separator) in values": function (test) {
-    compare(test,
-      "<root><child><inner>\r\n12\r\n3\r\n</inner></child></root>",
-      "//*[local-name(.)='child']",
-      "<child><inner>\n12\n3\n</inner></child>")
-  },
-
 
   "Exclusive canonicalization turns empty element to start-end tag pairs": function (test) {
     compare(test,

--- a/test/canonicalization-unit-tests.js
+++ b/test/canonicalization-unit-tests.js
@@ -181,31 +181,51 @@ module.exports = {
 
   "Exclusive canonicalization works on xml with attribute values with special characters": function (test) {
     compare(test,
-      "<root><child><inner attrEncoded=\"&amp;&lt;>&quot;&#xA;&#xD;&#x9;11\" attrUnencoded='&<>\"\n\r\t11'>11</inner></child></root>",
+      "<root><child><inner attrEncoded=\"&amp;&lt;>&quot;11\" attrUnencoded='&>\"11'>11</inner></child></root>",
       "//*[local-name(.)='child']",
-      "<child><inner attrEncoded=\"&amp;&lt;>&quot;&#xA;&#xD;&#x9;11\" attrUnencoded=\"&amp;&lt;>&quot;&#xA;&#xD;&#x9;11\">11</inner></child>")
+      "<child><inner attrEncoded=\"&amp;&lt;>&quot;11\" attrUnencoded=\"&amp;>&quot;11\">11</inner></child>")
+  },
+
+  "Exclusive canonicalization normalizes whitespace characters into single spaces": function (test) {
+    compare(test,
+        "<root><child><inner attrEncoded=\"&#xA;&#xD;&#x9;11\" attrUnencoded=\"\n\r\t11\">11</inner></child></root>",
+        "//*[local-name(.)='child']",
+        "<child><inner attrEncoded=\" 11\" attrUnencoded=\" 11\">11</inner></child>")
   },
 
   "Exclusive canonicalization works on xml with element values with special characters": function (test) {
     compare(test,
-        "<root><child><innerEncoded>&amp;&lt;>&quot;&#xD;&#x9;11</innerEncoded><innerUnencoded>&<>\"\r\n\t11\</innerUnencoded></child></root>",
+        "<root><child><innerEncoded>&amp;&lt;>&quot;11</innerEncoded><innerUnencoded>&>\"11\</innerUnencoded></child></root>",
         "//*[local-name(.)='child']",
-        "<child><innerEncoded>&amp;&lt;&gt;\"&#xD;\t11</innerEncoded><innerUnencoded>&amp;&lt;&gt;\"&#xD;\n\t11</innerUnencoded></child>")
+        "<child><innerEncoded>&amp;&lt;&gt;\"11</innerEncoded><innerUnencoded>&amp;&gt;\"11</innerUnencoded></child>")
   },
 
   "Exclusive canonicalization preserves white space in values": function (test) {
     compare(test,
-      "<root><child><inner>12\r3\t</inner></child></root>",
+      "<root><child><inner>12\n3\t</inner></child></root>",
       "//*[local-name(.)='child']",
-      "<child><inner>12&#xD;3\t</inner></child>")
+      "<child><inner>12\n3\t</inner></child>")
   },
 
-
-  "Exclusive canonicalization preserves white space bewteen elements": function (test) {
+  "Exclusive canonicalization turns CR-NL (windows line separator) into NL": function(test){
     compare(test,
-      "<root><child><inner>123</inner>\r</child></root>",
+        "<root><child><inner>123</inner>\r\n</child></root>",
+        "//*[local-name(.)='child']",
+        "<child><inner>123</inner>\n</child>")
+  },
+
+  "Exclusive canonicalization turns CR into NL": function(test){
+    compare(test,
+        "<root><child><inner>\r12\r3\r</inner></child></root>",
+        "//*[local-name(.)='child']",
+        "<child><inner>\n12\n3\n</inner></child>")
+  },
+
+  "Exclusive canonicalization preserves white space between elements": function (test) {
+    compare(test,
+      "<root><child><inner>123</inner>\n</child></root>",
       "//*[local-name(.)='child']",
-      "<child><inner>123</inner>&#xD;</child>")
+      "<child><inner>123</inner>\n</child>")
   },
 
   "Exclusive canonicalization turns empty element to start-end tag pairs": function (test) {
@@ -354,7 +374,7 @@ module.exports = {
       "  </Body>\r" +
       "</Envelope>",
       "//*[local-name(.)='Body']",
-      "<Body xmlns=\"http://schemas.xmlsoap.org/soap/envelope/\">&#xD;    <ACORD xmlns=\"http://www.ACORD.org/standards/PC_Surety/ACORD1.10.0/xml/\">&#xD;      <SignonRq>&#xD;        <SessKey></SessKey>&#xD;        <ClientDt></ClientDt>&#xD;        <CustLangPref></CustLangPref>&#xD;        <ClientApp>&#xD;          <Org xmlns:p6=\"http://www.w3.org/2001/XMLSchema-instance\" id=\"wewe\" p6:type=\"AssignedIdentifier\"></Org>&#xD;          <Name></Name>&#xD;          <Version></Version>&#xD;        </ClientApp>&#xD;        <ProxyClient>&#xD;          <Org xmlns:p6=\"http://www.w3.org/2001/XMLSchema-instance\" id=\"erer\" p6:type=\"AssignedIdentifier\"></Org>&#xD;          <Name>ererer</Name>&#xD;          <Version>dfdf</Version>&#xD;        </ProxyClient>&#xD;      </SignonRq>&#xD;      <InsuranceSvcRq>&#xD;        <RqUID></RqUID>&#xD;        <SPName id=\"rter\"></SPName>&#xD;        <QuickHit xmlns=\"urn:com.thehartford.bi.acord-extensions\">&#xD;          <StateProvCd xmlns=\"http://www.ACORD.org/standards/PC_Surety/ACORD1.10.0/xml/\" CodeListRef=\"dfdf\"></StateProvCd>&#xD;        </QuickHit>&#xD;        <WorkCompPolicyQuoteInqRq>&#xD;          <RqUID>erer</RqUID>&#xD;          <TransactionRequestDt id=\"erer\"></TransactionRequestDt>&#xD;          <CurCd></CurCd>&#xD;          <BroadLOBCd id=\"erer\"></BroadLOBCd>&#xD;          <InsuredOrPrincipal>&#xD;            <ItemIdInfo>&#xD;              <AgencyId id=\"3434\"></AgencyId>&#xD;              <OtherIdentifier>&#xD;                <CommercialName id=\"3434\"></CommercialName>&#xD;                <ContractTerm>&#xD;                  <EffectiveDt id=\"3434\"></EffectiveDt>&#xD;                  <StartTime id=\"3434\"></StartTime>&#xD;                </ContractTerm>&#xD;              </OtherIdentifier>&#xD;            </ItemIdInfo>&#xD;          </InsuredOrPrincipal>&#xD;          <InsuredOrPrincipal>&#xD;          </InsuredOrPrincipal>&#xD;          <CommlPolicy>&#xD;            <PolicyNumber id=\"3434\"></PolicyNumber>&#xD;            <LOBCd></LOBCd>&#xD;          </CommlPolicy>&#xD;          <WorkCompLineBusiness>&#xD;            <LOBCd></LOBCd>&#xD;            <WorkCompRateState>&#xD;              <WorkCompLocInfo>&#xD;              </WorkCompLocInfo>&#xD;            </WorkCompRateState>&#xD;          </WorkCompLineBusiness>&#xD;          <RemarkText IdRef=\"\">&#xD;          </RemarkText>&#xD;          <RemarkText IdRef=\"2323\" id=\"3434\">&#xD;          </RemarkText>&#xD;        </WorkCompPolicyQuoteInqRq>&#xD;      </InsuranceSvcRq>&#xD;    </ACORD>&#xD;  </Body>")
+      "<Body xmlns=\"http://schemas.xmlsoap.org/soap/envelope/\">\n    <ACORD xmlns=\"http://www.ACORD.org/standards/PC_Surety/ACORD1.10.0/xml/\">\n      <SignonRq>\n        <SessKey></SessKey>\n        <ClientDt></ClientDt>\n        <CustLangPref></CustLangPref>\n        <ClientApp>\n          <Org xmlns:p6=\"http://www.w3.org/2001/XMLSchema-instance\" id=\"wewe\" p6:type=\"AssignedIdentifier\"></Org>\n          <Name></Name>\n          <Version></Version>\n        </ClientApp>\n        <ProxyClient>\n          <Org xmlns:p6=\"http://www.w3.org/2001/XMLSchema-instance\" id=\"erer\" p6:type=\"AssignedIdentifier\"></Org>\n          <Name>ererer</Name>\n          <Version>dfdf</Version>\n        </ProxyClient>\n      </SignonRq>\n      <InsuranceSvcRq>\n        <RqUID></RqUID>\n        <SPName id=\"rter\"></SPName>\n        <QuickHit xmlns=\"urn:com.thehartford.bi.acord-extensions\">\n          <StateProvCd xmlns=\"http://www.ACORD.org/standards/PC_Surety/ACORD1.10.0/xml/\" CodeListRef=\"dfdf\"></StateProvCd>\n        </QuickHit>\n        <WorkCompPolicyQuoteInqRq>\n          <RqUID>erer</RqUID>\n          <TransactionRequestDt id=\"erer\"></TransactionRequestDt>\n          <CurCd></CurCd>\n          <BroadLOBCd id=\"erer\"></BroadLOBCd>\n          <InsuredOrPrincipal>\n            <ItemIdInfo>\n              <AgencyId id=\"3434\"></AgencyId>\n              <OtherIdentifier>\n                <CommercialName id=\"3434\"></CommercialName>\n                <ContractTerm>\n                  <EffectiveDt id=\"3434\"></EffectiveDt>\n                  <StartTime id=\"3434\"></StartTime>\n                </ContractTerm>\n              </OtherIdentifier>\n            </ItemIdInfo>\n          </InsuredOrPrincipal>\n          <InsuredOrPrincipal>\n          </InsuredOrPrincipal>\n          <CommlPolicy>\n            <PolicyNumber id=\"3434\"></PolicyNumber>\n            <LOBCd></LOBCd>\n          </CommlPolicy>\n          <WorkCompLineBusiness>\n            <LOBCd></LOBCd>\n            <WorkCompRateState>\n              <WorkCompLocInfo>\n              </WorkCompLocInfo>\n            </WorkCompRateState>\n          </WorkCompLineBusiness>\n          <RemarkText IdRef=\"\">\n          </RemarkText>\n          <RemarkText IdRef=\"2323\" id=\"3434\">\n          </RemarkText>\n        </WorkCompPolicyQuoteInqRq>\n      </InsuranceSvcRq>\n    </ACORD>\n  </Body>")
   },
 
   "Multiple Canonicalization with namespace definition outside of signed element": function (test) {


### PR DESCRIPTION
This is an attempt to fix several issues related to the canocalization of special characters. This fixes #28.

See:
- https://www.w3.org/TR/xml-c14n#ProcessingModel (Attribute Nodes, Text Nodes)
- https://www.w3.org/TR/xml-c14n#Example-Chars

Note: when checking the documentation of c14n or xml, it is very important to make sure you are viewing the latest version. It can happen quite easily that you are reading an outdated spec.

Pinging @cmordue @yaronn @bjrmatos 