### PR TITLE
Remove namespace-breaking reserialization of signature from example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Example:
 	var signature = select(doc, "/*/*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")[0]
 	var sig = new SignedXml()
 	sig.keyInfoProvider = new FileKeyInfo("client_public.pem")
-	sig.loadSignature(signature.toString())
+	sig.loadSignature(signature)
 	var res = sig.checkSignature(xml)
 	if (!res) console.log(sig.validationErrors)
 `````


### PR DESCRIPTION
This is a fix for the example signature validation documentation; the toString() call on the signature node turns out to be harmful, as it removes namespace metadata which would otherwise propagate from the parent document. In situations where the namespace is `ds`, this works out ok (as ds is provided as a default) but when using other strings for this namespace the example boilerplate fails.

In the example below, the definition of `dsig` would be undefined in a toString-orphaned signature, and the canonicalization algorithm would resolve the url as an empty string -- changing the underlying canonical text and causing the SignatureValue verification to fail.

```
<samlp:Response ... xmlns:dsig="http://www.w3.org/2000/09/xmldsig#">
  ...
    <dsig:Signature>
      <dsig:SignedInfo>
        <dsig:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
        <dsig:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
        <dsig:Reference URI="#id-2f7VgU-0XBjCqhLN2NWJyb-e5F2gWKOV9KT-c1nD">
          <dsig:Transforms>
            <dsig:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
            <dsig:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
          </dsig:Transforms>
          <dsig:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
          <dsig:DigestValue>...</dsig:DigestValue>
        </dsig:Reference>
      </dsig:SignedInfo>
     <dsig:SignatureValue>...</dsig:SignatureValue>
    </dsig:Signature>
  ...
</samlp:Response>
```

PR fixes this in the example, which realistically will get used as boilerplate in many integrations of this library. Having just spent three days chasing down the cause of one of our SAML integration failures, I think its a useful change.