### PR TITLE
Separate namespaces with same prefix but different URI

### DIFF
--- a/lib/exclusive-canonicalization.js
+++ b/lib/exclusive-canonicalization.js
@@ -56,6 +56,17 @@ ExclusiveCanonicalization.prototype.renderAttrs = function(node, defaultNS) {
   return res.join("");
 };
 
+function isPrefixInScope(prefixesInScope, prefix, namespaceURI)
+{
+  var ret = false;
+  prefixesInScope.forEach(function (pf) {
+    if (pf.prefix === prefix && pf.namespaceURI === namespaceURI) {
+      ret = true;
+    }
+  })
+
+  return ret;
+}
 
 /**
  * Create the string of all namespace declarations that should appear on this element
@@ -76,9 +87,9 @@ ExclusiveCanonicalization.prototype.renderNs = function(node, prefixesInScope, d
 
   //handle the namespaceof the node itself
   if (node.prefix) {
-    if (prefixesInScope.indexOf(node.prefix)==-1) {
+    if (!isPrefixInScope(prefixesInScope, node.prefix, node.namespaceURI || defaultNsForPrefix[node.prefix])) {
       nsListToRender.push({"prefix": node.prefix, "namespaceURI": node.namespaceURI || defaultNsForPrefix[node.prefix]});
-      prefixesInScope.push(node.prefix);
+      prefixesInScope.push({"prefix": node.prefix, "namespaceURI": node.namespaceURI || defaultNsForPrefix[node.prefix]});
     }
   }
   else if (defaultNs!=currNs) {
@@ -94,16 +105,16 @@ ExclusiveCanonicalization.prototype.renderNs = function(node, prefixesInScope, d
 
       //handle all prefixed attributes that are included in the prefix list and where
       //the prefix is not defined already
-      if (attr.prefix && prefixesInScope.indexOf(attr.localName) === -1 && inclusiveNamespacesPrefixList.indexOf(attr.localName) >= 0) {
+      if (attr.prefix && !isPrefixInScope(prefixesInScope, attr.localName, attr.value) && inclusiveNamespacesPrefixList.indexOf(attr.localName) >= 0) {
         nsListToRender.push({"prefix": attr.localName, "namespaceURI": attr.value});
-        prefixesInScope.push(attr.localName);
+        prefixesInScope.push({"prefix": attr.localName, "namespaceURI": attr.value});
       }
 
       //handle all prefixed attributes that are not xmlns definitions and where
       //the prefix is not defined already
-      if (attr.prefix && prefixesInScope.indexOf(attr.prefix)==-1 && attr.prefix!="xmlns" && attr.prefix!="xml") {
+      if (attr.prefix && !isPrefixInScope(prefixesInScope, attr.prefix, attr.namespaceURI) && attr.prefix!="xmlns" && attr.prefix!="xml") {
         nsListToRender.push({"prefix": attr.prefix, "namespaceURI": attr.namespaceURI});
-        prefixesInScope.push(attr.prefix);
+        prefixesInScope.push({"prefix": attr.prefix, "namespaceURI": attr.namespaceURI});
       }
     }
   }

--- a/test/canonicalization-unit-tests.js
+++ b/test/canonicalization-unit-tests.js
@@ -434,7 +434,13 @@ module.exports = {
 					  '<paketID xmlns="">3810016849-201501-KB-0000</paketID>'+
 					'</getBatchStatus>'+
 				  '</s:Body>')
+   },
+
+  "Overriding namespace in canonicalization": function (test) {
+    compare(test,
+            '<ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:InclusiveNamespaces xmlns:ds="http://www.w3.org/2001/10/xml-exc-c14n#"></ds:InclusiveNamespaces></ds:Signature>',
+            '//*',
+            '<ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:InclusiveNamespaces xmlns:ds="http://www.w3.org/2001/10/xml-exc-c14n#"></ds:InclusiveNamespaces></ds:Signature>',
+            'ds')
   }
-
-
 }


### PR DESCRIPTION
To allow namespace overriding in c14n.

We have a case in SAML response verification where the server sends XML with the same namespace prefix (ds) overridden on an inner element to a different URI, extract from actual sample attached. 

[namespace_override.txt](https://github.com/yaronn/xml-crypto/files/461722/namespace_override.txt)
