### PR TITLE
SignedXml.addExternalReference for references outside the main xml file

### DIFF
--- a/lib/signed-xml.js
+++ b/lib/signed-xml.js
@@ -447,6 +447,19 @@ SignedXml.prototype.addReference = function(xpath, transforms, digestAlgorithm, 
   });
 }
 
+SignedXml.prototype.addExternalReference = function(externalDoc, transforms, digestAlgorithm, uri, digestValue, inclusiveNamespacesPrefixList, isEmptyUri) {
+    this.references.push({
+      "xpath": null,
+      "transforms": transforms ? transforms : ["http://www.w3.org/2001/10/xml-exc-c14n#"] ,
+      "digestAlgorithm": digestAlgorithm ? digestAlgorithm : "http://www.w3.org/2000/09/xmldsig#sha1",
+      "uri": uri,
+      "digestValue": digestValue,
+      "inclusiveNamespacesPrefixList": inclusiveNamespacesPrefixList,
+      "isEmptyUri": isEmptyUri,
+      "externalDoc": externalDoc
+    });
+  }
+
 /**
  * Compute the signature of the given xml (usign the already defined settings)
  *
@@ -566,7 +579,8 @@ SignedXml.prototype.createReferences = function(doc, prefix) {
     if (!this.references.hasOwnProperty(n)) continue;
 
     var ref = this.references[n]
-      , nodes = select(doc, ref.xpath)
+
+    var nodes = ref.externalDoc ? [ref.externalDoc] : select(doc, ref.xpath)
 
     if (nodes.length==0) {
       throw new Error('the following xpath cannot be signed because it was not found: ' + ref.xpath)
@@ -580,9 +594,8 @@ SignedXml.prototype.createReferences = function(doc, prefix) {
         res += "<" + prefix + "Reference URI=\"\">"
       }
       else {
-        var id = this.ensureHasId(node);
-        ref.uri = id
-        res += "<" + prefix + "Reference URI=\"#" + id + "\">"
+        var id = ref.uri || '#' + this.ensureHasId(node);
+        res += "<" + prefix + "Reference URI=\"" + id + "\">"
       }
       res += "<" + prefix + "Transforms>"
       for (var t in ref.transforms) {


### PR DESCRIPTION
Hello, I've just added an addExternalReference function for references outside the document that's being signed (my scenario is a multipart/related HTTP request, so I need references to other MIME parts).

I've also made it so that ref.uri is used instead of a #id if specified (I needed the URI to be cid:Attachment1 or similar). Also I kept it away from XML processing because (1) attachments can be all content types and (2) ID fields are irrelevant if they're in different documents.

Let me know if this suits you or if you'd like to implement it a different way.

Cheers,
Matt