### PR TITLE
fixing attribute value normalization in Canonicalization

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -55,7 +55,7 @@ var xml_special_to_encoded_text = {
 
 function encodeSpecialCharactersInAttribute(attributeValue){
     return attributeValue
-        .replace(/[\r\n\t ]+/g, ' ') // White space normalization (Note: this should normally be done by the xml parser) See: https://www.w3.org/TR/xml/#AVNormalize
+        .replace(/[\r\n\t ]/g, ' ') // White space normalization (Note: this should normally be done by the xml parser) See: https://www.w3.org/TR/xml/#AVNormalize
         .replace(/([&<"\r\n\t])/g, function(str, item){
             // Special character normalization. See:
             // - https://www.w3.org/TR/xml-c14n#ProcessingModel (Attribute Nodes)


### PR DESCRIPTION
With Reference to https://www.w3.org/TR/xml/#AVNormalize
we need to append a space character (#x20) for a white space character (#x20, #xD, #xA, #x9) to the normalized value. But we are also replacing multiple spaces by single space.

Linking the issue raised [here](https://github.com/yaronn/xml-crypto/issues/148)