### PR TITLE
Patch for non exclusive c14n

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,30 @@ Note:
 The xml-crypto api requires you to supply it separately the xml signature ("&lt;Signature&gt;...&lt;/Signature&gt;", in loadSignature) and the signed xml (in checkSignature). The signed xml may or may not contain the signature in it, but you are still required to supply the signature separately.
 
 
+### Caring for Implicit transform
+If you fail to verify signed XML, then one possible cause is that there are some hidden implicit transforms(#).  
+(#) Normalizing XML document to be verified. i.e. remove extra space within a tag, sorting attributes, importing namespace declared in ancestor nodes, etc.
+
+The reason for these implicit transform might come from [complex xml signature specification](https://www.w3.org/TR/2002/REC-xmldsig-core-20020212),
+which makes XML developers confused and then leads to incorrect implementation for signing XML document.
+
+If you keep failing verification, it is worth trying to guess such a hidden transform and specify it to the option as below:
+
+```javascript
+var option = {implicitTransforms: ["http://www.w3.org/TR/2001/REC-xml-c14n-20010315"]}
+var sig = new SignedXml(null, option)
+sig.keyInfoProvider = new FileKeyInfo("client_public.pem")
+sig.loadSignature(signature)
+var res = sig.checkSignature(xml)
+```
+
+You might find it difficult to guess such transforms, but there are typical transforms you can try.
+
+- http://www.w3.org/TR/2001/REC-xml-c14n-20010315
+- http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments
+- http://www.w3.org/2001/10/xml-exc-c14n#
+- http://www.w3.org/2001/10/xml-exc-c14n#WithComments
+
 ## API
 
 ### xpath

--- a/lib/c14n-canonicalization.js
+++ b/lib/c14n-canonicalization.js
@@ -64,10 +64,12 @@ C14nCanonicalization.prototype.renderAttrs = function(node, defaultNS) {
  * @param {Array} prefixesInScope. The prefixes defined on this node
  *                parents which are a part of the output set
  * @param {String} defaultNs. The current default namespace
+ * @param {String} defaultNsForPrefix.
+ * @param {String} ancestorNamespaces - Import ancestor namespaces if it is specified
  * @return {String}
  * @api private
  */
-C14nCanonicalization.prototype.renderNs = function(node, prefixesInScope, defaultNs, defaultNsForPrefix) {
+C14nCanonicalization.prototype.renderNs = function(node, prefixesInScope, defaultNs, defaultNsForPrefix, ancestorNamespaces) {
   var a, i, p, attr
     , res = []
     , newDefaultNs = defaultNs
@@ -107,6 +109,17 @@ C14nCanonicalization.prototype.renderNs = function(node, prefixesInScope, defaul
       }
     }
   }
+  
+  if(Array.isArray(ancestorNamespaces) && ancestorNamespaces.length > 0){
+    // Remove namespaces which are already present in nsListToRender
+    ancestorNamespaces = ancestorNamespaces.filter(function(ancestorNs){
+      return !nsListToRender.some(function(nsToBeRendered){
+        return nsToBeRendered.prefix === ancestorNs.prefix && nsToBeRendered.namespaceURI === ancestorNs.namespaceURI;
+      });
+    });
+    
+    nsListToRender = [].concat(nsListToRender, ancestorNamespaces);
+  }
 
   nsListToRender.sort(this.nsCompare);
 
@@ -121,18 +134,18 @@ C14nCanonicalization.prototype.renderNs = function(node, prefixesInScope, defaul
   return {"rendered": res.join(""), "newDefaultNs": newDefaultNs};
 };
 
-C14nCanonicalization.prototype.processInner = function(node, prefixesInScope, defaultNs, defaultNsForPrefix) {
+C14nCanonicalization.prototype.processInner = function(node, prefixesInScope, defaultNs, defaultNsForPrefix, ancestorNamespaces) {
 
   if (node.nodeType === 8) { return this.renderComment(node); }
   if (node.data) { return utils.encodeSpecialCharactersInText(node.data); }
 
   var i, pfxCopy
-    , ns = this.renderNs(node, prefixesInScope, defaultNs, defaultNsForPrefix)
+    , ns = this.renderNs(node, prefixesInScope, defaultNs, defaultNsForPrefix, ancestorNamespaces)
     , res = ["<", node.tagName, ns.rendered, this.renderAttrs(node, ns.newDefaultNs), ">"];
 
   for (i = 0; i < node.childNodes.length; ++i) {
     pfxCopy = prefixesInScope.slice(0);
-    res.push(this.processInner(node.childNodes[i], pfxCopy, ns.newDefaultNs, defaultNsForPrefix));
+    res.push(this.processInner(node.childNodes[i], pfxCopy, ns.newDefaultNs, defaultNsForPrefix, []));
   }
 
   res.push("</", node.tagName, ">");
@@ -185,8 +198,9 @@ C14nCanonicalization.prototype.process = function(node, options) {
   options = options || {};
   var defaultNs = options.defaultNs || "";
   var defaultNsForPrefix = options.defaultNsForPrefix || {};
+  var ancestorNamespaces = options.ancestorNamespaces || [];
 
-  var res = this.processInner(node, [], defaultNs, defaultNsForPrefix);
+  var res = this.processInner(node, [], defaultNs, defaultNsForPrefix, ancestorNamespaces);
   return res;
 };
 

--- a/lib/signed-xml.js
+++ b/lib/signed-xml.js
@@ -295,6 +295,8 @@ SignedXml.defaultNsForPrefix = {
   ds: 'http://www.w3.org/2000/09/xmldsig#'
 };
 
+SignedXml.findAncestorNs = findAncestorNs;
+
 SignedXml.prototype.checkSignature = function(xml) {
   this.validationErrors = []
   this.signedXml = xml

--- a/lib/signed-xml.js
+++ b/lib/signed-xml.js
@@ -215,7 +215,40 @@ function findAncestorNs(doc, docSubsetXpath){
     return [];
   }
   
-  return collectAncestorNamespaces(docSubset[0]);
+  // Remove duplicate on ancestor namespace
+  var ancestorNs = collectAncestorNamespaces(docSubset[0]);
+  var ancestorNsWithoutDuplicate = [];
+  for(var i=0;i<ancestorNs.length;i++){
+    var notOnTheList = ancestorNsWithoutDuplicate.findIndex(function(v){
+      return v.prefix === ancestorNs[i].prefix;
+    }) === -1;
+    
+    if(notOnTheList){
+      ancestorNsWithoutDuplicate.push(ancestorNs[i]);
+    }
+  }
+  
+  // Remove namespaces which are already declared in the subset with the same prefix
+  var returningNs = [];
+  var subsetAttributes = docSubset[0].attributes;
+  for(var j=0;j<ancestorNsWithoutDuplicate.length;j++){
+    var isUnique = true;
+    for(var k=0;k<subsetAttributes.length;k++){
+      var nodeName = subsetAttributes[k].nodeName;
+      if(!nodeName.startsWith("xmlns:")) continue;
+      var prefix = nodeName.replace(/^xmlns:/, "");
+      if(ancestorNsWithoutDuplicate[j].prefix === prefix){
+        isUnique = false;
+        break;
+      }
+    }
+  
+    if(isUnique){
+      returningNs.push(ancestorNsWithoutDuplicate[j]);
+    }
+  }
+  
+  return returningNs;
 }
 
 

--- a/lib/signed-xml.js
+++ b/lib/signed-xml.js
@@ -6,6 +6,7 @@ var select = require('xpath.js')
   , EnvelopedSignature = require('./enveloped-signature').EnvelopedSignature
   , crypto = require('crypto')
   , fs = require('fs')
+  , xpath = require('xpath.js')
 
 exports.SignedXml = SignedXml
 exports.FileKeyInfo = FileKeyInfo
@@ -197,6 +198,51 @@ function HMACSHA1() {
     };
 }
 
+
+
+/**
+ * Extract ancestor namespaces in order to import it to root of document subset
+ * which is being canonicalized for non-exclusive c14n.
+ *
+ * @param {object} doc - Usually a product from `new DOMParser().parseFromString()`
+ * @param {string} docSubsetXpath - xpath query to get document subset being canonicalized
+ * @returns {Array} i.e. [{prefix: "saml", namespaceURI: "urn:oasis:names:tc:SAML:2.0:assertion"}]
+ */
+function findAncestorNs(doc, docSubsetXpath){
+  var docSubset = xpath(doc, docSubsetXpath);
+  
+  if(!Array.isArray(docSubset) || docSubset.length < 1){
+    return [];
+  }
+  
+  return collectAncestorNamespaces(docSubset[0]);
+}
+
+
+
+function collectAncestorNamespaces(node, nsArray){
+  if(!nsArray){
+    nsArray = [];
+  }
+  
+  var parent = node.parentNode;
+  
+  if(!parent){
+    return nsArray;
+  }
+  
+  if(parent.attributes && parent.attributes.length > 0){
+    for(var i=0;i<parent.attributes.length;i++){
+      var attr = parent.attributes[i];
+      if(attr.nodeName.startsWith("xmlns:")){
+        nsArray.push({prefix: attr.nodeName.replace(/^xmlns:/, ""), namespaceURI: attr.nodeValue})
+      }
+    }
+  }
+  
+  return collectAncestorNamespaces(parent, nsArray);
+}
+
 /**
 * Xml signature implementation
 *
@@ -264,18 +310,38 @@ SignedXml.prototype.checkSignature = function(xml) {
   if (!this.validateReferences(doc)) {
     return false;
   }
-
-  if (!this.validateSignatureValue()) {
+  
+  if (!this.validateSignatureValue(doc)) {
     return false;
   }
 
   return true
 }
 
-SignedXml.prototype.validateSignatureValue = function() {
+SignedXml.prototype.validateSignatureValue = function(doc) {
   var signedInfo = utils.findChilds(this.signatureNode, "SignedInfo")
   if (signedInfo.length==0) throw new Error("could not find SignedInfo element in the message")
-  var signedInfoCanon = this.getCanonXml([this.canonicalizationAlgorithm], signedInfo[0])
+  
+  /**
+   * When canonicalization algorithm is non-exclusive, search for ancestor namespaces
+   * before validating signature.
+   */
+  var ancestorNamespaces = [];
+  if([
+    'http://www.w3.org/TR/2001/REC-xml-c14n-20010315',
+    'http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments'
+  ].includes(this.canonicalizationAlgorithm)){
+    if(!doc || typeof(doc) !== "object"){
+      throw new Error("When canonicalization method is non-exclusive, whole xml dom must be provided as an argument");
+    }
+    
+    ancestorNamespaces = findAncestorNs(doc, "//*[local-name()='SignedInfo']");
+  }
+  
+  var c14nOptions = {
+    ancestorNamespaces: ancestorNamespaces
+  };
+  var signedInfoCanon = this.getCanonXml([this.canonicalizationAlgorithm], signedInfo[0], c14nOptions)
   var signer = this.findSignatureAlgorithm(this.signatureAlgorithm)
   var res = signer.verifySignature(signedInfoCanon, this.signingKey, this.signatureValue)
   if (!res) this.validationErrors.push("invalid signature: the signature value " +
@@ -310,6 +376,7 @@ SignedXml.prototype.validateReferences = function(doc) {
 
     var uri = ref.uri[0]=="#" ? ref.uri.substring(1) : ref.uri
     var elem = [];
+    var elemXpath;
 
     if (uri=="") {
       elem = select(doc, "//*")
@@ -322,11 +389,13 @@ SignedXml.prototype.validateReferences = function(doc) {
       var num_elements_for_id = 0;
       for (var index in this.idAttributes) {
         if (!this.idAttributes.hasOwnProperty(index)) continue;
-        var tmp_elem = select(doc, "//*[@*[local-name(.)='" + this.idAttributes[index] + "']='" + uri + "']")
+        var tmp_elemXpath = "//*[@*[local-name(.)='" + this.idAttributes[index] + "']='" + uri + "']";
+        var tmp_elem = select(doc, tmp_elemXpath)
         num_elements_for_id += tmp_elem.length;
         if (tmp_elem.length > 0) {
           elem = tmp_elem;
-        };
+          elemXpath = tmp_elemXpath;
+        }
       }
       if (num_elements_for_id > 1) {
           throw new Error('Cannot validate a document which contains multiple elements with the ' +
@@ -340,7 +409,29 @@ SignedXml.prototype.validateReferences = function(doc) {
                         ref.uri + " but could not find such element in the xml")
       return false
     }
-    var canonXml = this.getCanonXml(ref.transforms, elem[0], { inclusiveNamespacesPrefixList: ref.inclusiveNamespacesPrefixList });
+  
+    /**
+     * When canonicalization algorithm is non-exclusive, search for ancestor namespaces
+     * before validating references.
+     */
+    if(Array.isArray(ref.transforms)){
+      var hasNonExcC14nTransform = ref.transforms.some(function(t){
+        return [
+          'http://www.w3.org/TR/2001/REC-xml-c14n-20010315',
+          'http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments'
+        ].includes(t);
+      });
+    
+      if(hasNonExcC14nTransform){
+        ref.ancestorNamespaces = findAncestorNs(doc, elemXpath);
+      }
+    }
+  
+    var c14nOptions = {
+      inclusiveNamespacesPrefixList: ref.inclusiveNamespacesPrefixList,
+      ancestorNamespaces: ref.ancestorNamespaces
+    };
+    var canonXml = this.getCanonXml(ref.transforms, elem[0], c14nOptions);
 
     var hash = this.findHashAlgorithm(ref.digestAlgorithm)
     var digest = hash.getHash(canonXml)
@@ -610,7 +701,7 @@ SignedXml.prototype.getCanonXml = function(transforms, node, options) {
   options = options || {};
   options.defaultNsForPrefix = options.defaultNsForPrefix || SignedXml.defaultNsForPrefix;
 
-  var canonXml = node
+  var canonXml = node.cloneNode(true) // Deep clone
 
   for (var t in transforms) {
     if (!transforms.hasOwnProperty(t)) continue;

--- a/lib/signed-xml.js
+++ b/lib/signed-xml.js
@@ -267,6 +267,7 @@ function SignedXml(idMode, options) {
   this.keyInfo = null
   this.idAttributes = [ 'Id', 'ID', 'id' ];
   if (this.options.idAttribute) this.idAttributes.splice(0, 0, this.options.idAttribute);
+  this.implicitTransforms = this.options.implicitTransforms || [];
 }
 
 SignedXml.CanonicalizationAlgorithms = {
@@ -519,8 +520,15 @@ SignedXml.prototype.loadReference = function(ref) {
     }
   }
 
+  var hasImplicitTransforms = (Array.isArray(this.implicitTransforms) && this.implicitTransforms.length > 0);
+  if(hasImplicitTransforms){
+    this.implicitTransforms.forEach(function(t){
+      transforms.push(t);
+    });
+  }
+  
   //***workaround for validating windows mobile store signatures - it uses c14n but does not state it in the transforms
-  if (transforms.length==1 && transforms[0]=="http://www.w3.org/2000/09/xmldsig#enveloped-signature")
+  if (!hasImplicitTransforms && transforms.length==1 && transforms[0]=="http://www.w3.org/2000/09/xmldsig#enveloped-signature")
     transforms.push("http://www.w3.org/2001/10/xml-exc-c14n#")
 
   this.addReference(null, transforms, digestAlgo, utils.findAttr(ref, "URI").value, digestValue, inclusiveNamespacesPrefixList, false)

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
   ],
   "license": "MIT",
   "scripts": {
-    "test": "nodeunit ./test/canonicalization-unit-tests.js ./test/c14nWithComments-unit-tests.js ./test/signature-unit-tests.js ./test/saml-response-test.js ./test/signature-integration-tests.js ./test/document-test.js ./test/wsfed-metadata-test.js ./test/hmac-tests.js"
+    "test": "nodeunit ./test/canonicalization-unit-tests.js ./test/c14nWithComments-unit-tests.js ./test/signature-unit-tests.js ./test/saml-response-test.js ./test/signature-integration-tests.js ./test/document-test.js ./test/wsfed-metadata-test.js ./test/hmac-tests.js ./test/c14n-non-exclusive-unit-test.js"
   }
 }

--- a/test/c14n-non-exclusive-unit-test.js
+++ b/test/c14n-non-exclusive-unit-test.js
@@ -1,0 +1,182 @@
+var C14nCanonicalization = require("../lib/c14n-canonicalization").C14nCanonicalization
+  , Dom = require('xmldom').DOMParser
+  , select = require('xpath.js')
+  , findAncestorNs = require('../lib/signed-xml').SignedXml.findAncestorNs
+
+var test_C14nCanonicalization = function(test, xml, xpath, expected) {
+  var doc = new Dom().parseFromString(xml);
+  var elem = select(doc, xpath)[0];
+  var can = new C14nCanonicalization();
+  var result = can.process(elem, {
+    ancestorNamespaces: findAncestorNs(doc, xpath)
+  }).toString();
+  
+  test.equal(result, expected);
+  test.done()
+};
+
+var test_findAncestorNs = function(test, xml, xpath, expected){
+  var doc = new Dom().parseFromString(xml);
+  var result = findAncestorNs(doc, xpath);
+  test.deepEqual(result, expected);
+  
+  test.done();
+};
+
+
+
+
+
+
+exports["findAncestorNs: Correctly picks up root ancestor namespace"] = function(test){
+  var xml = "<root xmlns:aaa='bbb'><child1><child2></child2></child1></root>";
+  var xpath = "/root/child1/child2";
+  var expected = [
+    {prefix: "aaa", namespaceURI: "bbb"}
+    ];
+  
+  test_findAncestorNs(test, xml, xpath, expected);
+};
+
+exports["findAncestorNs: Correctly picks up intermediate ancestor namespace"] = function(test){
+  var xml = "<root><child1 xmlns:aaa='bbb'><child2></child2></child1></root>";
+  var xpath = "/root/child1/child2";
+  var expected = [
+    {prefix: "aaa", namespaceURI: "bbb"}
+  ];
+  
+  test_findAncestorNs(test, xml, xpath, expected);
+};
+
+exports["findAncestorNs: Correctly picks up multiple ancestor namespaces declared in the one same element"] = function(test){
+  var xml = "<root xmlns:aaa='bbb' xmlns:ccc='ddd'><child1><child2></child2></child1></root>";
+  var xpath = "/root/child1/child2";
+  var expected = [
+    {prefix: "aaa", namespaceURI: "bbb"},
+    {prefix: "ccc", namespaceURI: "ddd"}
+  ];
+  
+  test_findAncestorNs(test, xml, xpath, expected);
+};
+
+exports["findAncestorNs: Correctly picks up multiple ancestor namespaces scattered among depth"] = function(test){
+  var xml = "<root xmlns:aaa='bbb'><child1 xmlns:ccc='ddd'><child2></child2></child1></root>";
+  var xpath = "/root/child1/child2";
+  var expected = [
+    {prefix: "ccc", namespaceURI: "ddd"},
+    {prefix: "aaa", namespaceURI: "bbb"}
+  ];
+  
+  test_findAncestorNs(test, xml, xpath, expected);
+};
+
+exports["findAncestorNs: Correctly picks up multiple ancestor namespaces without duplicate"] = function(test){
+  var xml = "<root xmlns:ccc='bbb'><child1 xmlns:ccc='bbb'><child2></child2></child1></root>";
+  var xpath = "/root/child1/child2";
+  var expected = [
+    {prefix: "ccc", namespaceURI: "bbb"}
+  ];
+  
+  test_findAncestorNs(test, xml, xpath, expected);
+};
+
+exports["findAncestorNs: Correctly eliminates duplicate prefix"] = function(test){
+  var xml = "<root xmlns:ccc='bbb'><child1 xmlns:ccc='AAA'><child2></child2></child1></root>";
+  var xpath = "/root/child1/child2";
+  var expected = [
+    {prefix: "ccc", namespaceURI: "AAA"}
+  ];
+  
+  test_findAncestorNs(test, xml, xpath, expected);
+};
+
+exports["findAncestorNs: Exclude namespace which is already declared with same prefix on target node"] = function(test){
+  var xml = "<root xmlns:ccc='bbb'><child1 xmlns:ccc='AAA'><child2 xmlns:ccc='AAA'></child2></child1></root>";
+  var xpath = "/root/child1/child2";
+  var expected = [];
+  
+  test_findAncestorNs(test, xml, xpath, expected);
+};
+
+exports["findAncestorNs: Ignores namespace declared in the target xpath node"] = function(test){
+  var xml = "<root xmlns:aaa='bbb'><child1><child2 xmlns:ccc='ddd'></child2></child1></root>";
+  var xpath = "/root/child1/child2";
+  var expected = [
+    {prefix: "aaa", namespaceURI: "bbb"}
+  ];
+  
+  test_findAncestorNs(test, xml, xpath, expected);
+};
+
+
+
+
+
+
+
+
+
+
+exports["C14n: Correctly picks up root ancestor namespace"] = function(test){
+  var xml = "<root xmlns:aaa='bbb'><child1><child2></child2></child1></root>";
+  var xpath = "/root/child1/child2";
+  var expected = '<child2 xmlns:aaa="bbb"></child2>';
+  
+  test_C14nCanonicalization(test, xml, xpath, expected);
+};
+
+exports["C14n: Correctly picks up intermediate ancestor namespace"] = function(test){
+  var xml = "<root><child1 xmlns:aaa='bbb'><child2></child2></child1></root>";
+  var xpath = "/root/child1/child2";
+  var expected = '<child2 xmlns:aaa="bbb"></child2>';
+  
+  test_C14nCanonicalization(test, xml, xpath, expected);
+};
+
+exports["C14n: Correctly picks up multiple ancestor namespaces declared in the one same element"] = function(test){
+  var xml = "<root xmlns:aaa='bbb' xmlns:ccc='ddd'><child1><child2></child2></child1></root>";
+  var xpath = "/root/child1/child2";
+  var expected = '<child2 xmlns:aaa="bbb" xmlns:ccc="ddd"></child2>';
+  
+  test_C14nCanonicalization(test, xml, xpath, expected);
+};
+
+exports["C14n: Correctly picks up multiple ancestor namespaces scattered among depth"] = function(test){
+  var xml = "<root xmlns:aaa='bbb'><child1 xmlns:ccc='ddd'><child2></child2></child1></root>";
+  var xpath = "/root/child1/child2";
+  var expected = '<child2 xmlns:aaa="bbb" xmlns:ccc="ddd"></child2>';
+  
+  test_C14nCanonicalization(test, xml, xpath, expected);
+};
+
+exports["C14n: Correctly picks up multiple ancestor namespaces without duplicate"] = function(test){
+  var xml = "<root xmlns:ccc='bbb'><child1 xmlns:ccc='bbb'><child2></child2></child1></root>";
+  var xpath = "/root/child1/child2";
+  var expected = '<child2 xmlns:ccc="bbb"></child2>';
+  
+  test_C14nCanonicalization(test, xml, xpath, expected);
+};
+
+exports["C14n: Correctly eliminates duplicate prefix"] = function(test){
+  var xml = "<root xmlns:ccc='bbb'><child1 xmlns:ccc='AAA'><child2></child2></child1></root>";
+  var xpath = "/root/child1/child2";
+  var expected = '<child2 xmlns:ccc="AAA"></child2>';
+  
+  test_C14nCanonicalization(test, xml, xpath, expected);
+};
+
+exports["C14n: Exclude namespace which is already declared with same prefix on target node"] = function(test){
+  var xml = "<root xmlns:ccc='bbb'><child1 xmlns:ccc='AAA'><child2 xmlns:ccc='AAA'></child2></child1></root>";
+  var xpath = "/root/child1/child2";
+  var expected = '<child2 xmlns:ccc="AAA"></child2>';
+  
+  test_C14nCanonicalization(test, xml, xpath, expected);
+};
+
+exports["C14n: Preserve namespace declared in the target xpath node"] = function(test){
+  var xml = '<root xmlns:aaa="bbb"><child1><child2 xmlns:ccc="ddd"></child2></child1></root>';
+  var xpath = "/root/child1/child2";
+  var expected = '<child2 xmlns:aaa="bbb" xmlns:ccc="ddd"></child2>';
+  
+  test_C14nCanonicalization(test, xml, xpath, expected);
+};


### PR DESCRIPTION
# Summary
This is a patch proposal for issues regarding to non-exclusive c14n handling bug.
This PR contains README update and corresponding unit test specs.

Issues relating:
https://github.com/yaronn/xml-crypto/issues/113
https://github.com/yaronn/xml-crypto/issues/153

# Optional Suggestion
As you know, there is a quick-patch in `lib/signed-xml.js` as below.  
```
  //***workaround for validating windows mobile store signatures - it uses c14n but does not state it in the transforms
  if (!hasImplicitTransforms && transforms.length==1 && transforms[0]=="http://www.w3.org/2000/09/xmldsig#enveloped-signature")
    transforms.push("http://www.w3.org/2001/10/xml-exc-c14n#")
```

I found that there are a lot of signed XML in the world with **implicit** transforms.
Not limited to "_validating windows mobile store signatures_", sometimes developers need to guess 
and apply those hidden implicit transform.

So I added option to specify such implicit transform like this:
```
new SignedXml(null, {implicitTransforms: ["http://www.w3.org/2001/10/xml-exc-c14n#"]});
```

This new option is described in README in my PR.

Then this is a suggestion.

**Can we eliminate the workaround code for windows mobile store signature?**

I know there will be an breaking impact on current xml-crypto users, but it is healthier to specify such an implicit transform into an option.

Currently, my PR preserves that workaround code. So if you are worried to have impacts on existing users, you can safely ignore my suggestion.

Best regards.