### PR TITLE
Bugfix: a namespace in the inclusive namespace list should be treated…

### DIFF
--- a/lib/exclusive-canonicalization.js
+++ b/lib/exclusive-canonicalization.js
@@ -105,10 +105,10 @@ ExclusiveCanonicalization.prototype.renderNs = function(node,
   }
 
   if(topNode) {
-    for(let j = 0; j < ancestorNamespaces.length; j++) {
-      let ancestorNs = ancestorNamespaces[j];
-      for(let k = 0; k < inclusiveNamespacesPrefixList.length; k++) {
-        let inclusiveNs = inclusiveNamespacesPrefixList[k];
+    for(var j = 0; j < ancestorNamespaces.length; j++) {
+      var ancestorNs = ancestorNamespaces[j];
+      for(var k = 0; k < inclusiveNamespacesPrefixList.length; k++) {
+        var inclusiveNs = inclusiveNamespacesPrefixList[k];
         if(ancestorNs.prefix === inclusiveNs && !isPrefixInScope(prefixesInScope, ancestorNs.prefix, ancestorNs.namespaceURI)) {
           nsListToRender.push({"prefix": ancestorNs.prefix, "namespaceURI": ancestorNs.namespaceURI});
           prefixesInScope.push({"prefix": ancestorNs.prefix, "namespaceURI": ancestorNs.namespaceURI});
@@ -135,13 +135,13 @@ ExclusiveCanonicalization.prototype.renderNs = function(node,
       //handle all prefixed attributes that are not xmlns definitions and where
       //the prefix is not defined already
       if (attr.prefix && attr.prefix!=="xmlns" && attr.prefix!=="xml") {
-        let artificiallyIntroduced = false;
+        var artificiallyIntroduced = false;
         if(attr.namespaceURI === undefined) {
           //This could mean that the namespace Uri has been reset to "", or it could mean we have artificially
           //introduced it because it was in inclusiveNamespacePrefixList
           if(inclusiveNamespacesPrefixList.indexOf(attr.prefix) >= 0) {
-            for(let j = 0; j < ancestorNamespaces.length; j++) {
-              let ancestorNs = ancestorNamespaces[j];
+            for(var j = 0; j < ancestorNamespaces.length; j++) {
+              var ancestorNs = ancestorNamespaces[j];
               if(ancestorNs.prefix === attr.prefix) {
                 artificiallyIntroduced = true;
                 break;

--- a/lib/exclusive-canonicalization.js
+++ b/lib/exclusive-canonicalization.js
@@ -78,13 +78,19 @@ function isPrefixInScope(prefixesInScope, prefix, namespaceURI)
  * @return {String}
  * @api private
  */
-ExclusiveCanonicalization.prototype.renderNs = function(node, prefixesInScope, defaultNs, defaultNsForPrefix, inclusiveNamespacesPrefixList) {
+ExclusiveCanonicalization.prototype.renderNs = function(node,
+                                                        prefixesInScope,
+                                                        defaultNs,
+                                                        defaultNsForPrefix,
+                                                        inclusiveNamespacesPrefixList,
+                                                        ancestorNamespaces,
+                                                        topNode,
+                                                        ) {
   var a, i, p, attr
     , res = []
     , newDefaultNs = defaultNs
     , nsListToRender = []
     , currNs = node.namespaceURI || "";
-
   //handle the namespaceof the node itself
   if (node.prefix) {
     if (!isPrefixInScope(prefixesInScope, node.prefix, node.namespaceURI || defaultNsForPrefix[node.prefix])) {
@@ -98,23 +104,57 @@ ExclusiveCanonicalization.prototype.renderNs = function(node, prefixesInScope, d
       res.push(' xmlns="', newDefaultNs, '"');
   }
 
+  if(topNode) {
+    for(let j = 0; j < ancestorNamespaces.length; j++) {
+      let ancestorNs = ancestorNamespaces[j];
+      for(let k = 0; k < inclusiveNamespacesPrefixList.length; k++) {
+        let inclusiveNs = inclusiveNamespacesPrefixList[k];
+        if(ancestorNs.prefix === inclusiveNs && !isPrefixInScope(prefixesInScope, ancestorNs.prefix, ancestorNs.namespaceURI)) {
+          nsListToRender.push({"prefix": ancestorNs.prefix, "namespaceURI": ancestorNs.namespaceURI});
+          prefixesInScope.push({"prefix": ancestorNs.prefix, "namespaceURI": ancestorNs.namespaceURI});
+        }
+      }
+    }
+  }
+
   //handle the attributes namespace
   if (node.attributes) {
     for (i = 0; i < node.attributes.length; ++i) {
       attr = node.attributes[i];
 
+
       //handle all prefixed attributes that are included in the prefix list and where
       //the prefix is not defined already
-      if (attr.prefix && !isPrefixInScope(prefixesInScope, attr.localName, attr.value) && inclusiveNamespacesPrefixList.indexOf(attr.localName) >= 0) {
+      if (attr.prefix &&
+        !isPrefixInScope(prefixesInScope, attr.localName, attr.value) &&
+        (inclusiveNamespacesPrefixList.indexOf(attr.localName) >= 0)) {
         nsListToRender.push({"prefix": attr.localName, "namespaceURI": attr.value});
         prefixesInScope.push({"prefix": attr.localName, "namespaceURI": attr.value});
       }
 
       //handle all prefixed attributes that are not xmlns definitions and where
       //the prefix is not defined already
-      if (attr.prefix && !isPrefixInScope(prefixesInScope, attr.prefix, attr.namespaceURI) && attr.prefix!="xmlns" && attr.prefix!="xml") {
-        nsListToRender.push({"prefix": attr.prefix, "namespaceURI": attr.namespaceURI});
-        prefixesInScope.push({"prefix": attr.prefix, "namespaceURI": attr.namespaceURI});
+      if (attr.prefix && attr.prefix!=="xmlns" && attr.prefix!=="xml") {
+        let artificiallyIntroduced = false;
+        if(attr.namespaceURI === undefined) {
+          //This could mean that the namespace Uri has been reset to "", or it could mean we have artificially
+          //introduced it because it was in inclusiveNamespacePrefixList
+          if(inclusiveNamespacesPrefixList.indexOf(attr.prefix) >= 0) {
+            for(let j = 0; j < ancestorNamespaces.length; j++) {
+              let ancestorNs = ancestorNamespaces[j];
+              if(ancestorNs.prefix === attr.prefix) {
+                artificiallyIntroduced = true;
+                break;
+              }
+            }
+          }
+        }
+        if(!artificiallyIntroduced) {
+          if(!isPrefixInScope(prefixesInScope, attr.prefix, attr.namespaceURI)) {
+            nsListToRender.push({"prefix": attr.prefix, "namespaceURI": attr.namespaceURI|| defaultNsForPrefix[attr.prefix]});
+            prefixesInScope.push({"prefix": attr.prefix, "namespaceURI": attr.namespaceURI|| defaultNsForPrefix[attr.prefix]});
+          }
+        }
       }
     }
   }
@@ -132,18 +172,23 @@ ExclusiveCanonicalization.prototype.renderNs = function(node, prefixesInScope, d
   return {"rendered": res.join(""), "newDefaultNs": newDefaultNs};
 };
 
-ExclusiveCanonicalization.prototype.processInner = function(node, prefixesInScope, defaultNs, defaultNsForPrefix, inclusiveNamespacesPrefixList) {
-
+ExclusiveCanonicalization.prototype.processInner = function(node,
+                                                            prefixesInScope,
+                                                            defaultNs,
+                                                            defaultNsForPrefix,
+                                                            inclusiveNamespacesPrefixList,
+                                                            ancestorNamespaces,
+                                                            topNode) {
   if (node.nodeType === 8) { return this.renderComment(node); }
   if (node.data) { return utils.encodeSpecialCharactersInText(node.data); }
 
   var i, pfxCopy
-    , ns = this.renderNs(node, prefixesInScope, defaultNs, defaultNsForPrefix, inclusiveNamespacesPrefixList)
+    , ns = this.renderNs(node, prefixesInScope, defaultNs, defaultNsForPrefix, inclusiveNamespacesPrefixList, ancestorNamespaces, topNode)
     , res = ["<", node.tagName, ns.rendered, this.renderAttrs(node, ns.newDefaultNs), ">"];
 
   for (i = 0; i < node.childNodes.length; ++i) {
     pfxCopy = prefixesInScope.slice(0);
-    res.push(this.processInner(node.childNodes[i], pfxCopy, ns.newDefaultNs, defaultNsForPrefix, inclusiveNamespacesPrefixList));
+    res.push(this.processInner(node.childNodes[i], pfxCopy, ns.newDefaultNs, defaultNsForPrefix, inclusiveNamespacesPrefixList, ancestorNamespaces, false));
   }
 
   res.push("</", node.tagName, ">");
@@ -197,9 +242,10 @@ ExclusiveCanonicalization.prototype.process = function(node, options) {
   var inclusiveNamespacesPrefixList = options.inclusiveNamespacesPrefixList || [];
   var defaultNs = options.defaultNs || "";
   var defaultNsForPrefix = options.defaultNsForPrefix || {};
+  var ancestorNamespaces = options.ancestorNamespaces || [];
   if (!(inclusiveNamespacesPrefixList instanceof Array)) { inclusiveNamespacesPrefixList = inclusiveNamespacesPrefixList.split(' '); }
 
-  var res = this.processInner(node, [], defaultNs, defaultNsForPrefix, inclusiveNamespacesPrefixList);
+  var res = this.processInner(node, [], defaultNs, defaultNsForPrefix, inclusiveNamespacesPrefixList, ancestorNamespaces, true);
   return res;
 };
 

--- a/lib/exclusive-canonicalization.js
+++ b/lib/exclusive-canonicalization.js
@@ -84,7 +84,7 @@ ExclusiveCanonicalization.prototype.renderNs = function(node,
                                                         defaultNsForPrefix,
                                                         inclusiveNamespacesPrefixList,
                                                         ancestorNamespaces,
-                                                        topNode,
+                                                        topNode
                                                         ) {
   var a, i, p, attr
     , res = []

--- a/lib/signed-xml.js
+++ b/lib/signed-xml.js
@@ -450,21 +450,11 @@ SignedXml.prototype.validateReferences = function(doc) {
     }
   
     /**
-     * When canonicalization algorithm is non-exclusive, search for ancestor namespaces
-     * before validating references.
+     * Search for ancestor namespaces before validating references. Ancestor namespaces are needed
+     * even for exclusive canonicalization because they may be needed for namespaces that are on the
+     * inclusive namespace prefix list.
      */
     if(Array.isArray(ref.transforms)){
-      var hasNonExcC14nTransform = false;
-      for(var t in ref.transforms){
-        if(!ref.transforms.hasOwnProperty(t)) continue;
-        
-        if(ref.transforms[t] === "http://www.w3.org/TR/2001/REC-xml-c14n-20010315"
-        || ref.transforms[t] === "http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments")
-        {
-          hasNonExcC14nTransform = true;
-          break;
-        }
-      }
       ref.ancestorNamespaces = findAncestorNs(doc, elemXpath);
     }
   

--- a/lib/signed-xml.js
+++ b/lib/signed-xml.js
@@ -374,9 +374,9 @@ SignedXml.prototype.validateSignatureValue = function(doc) {
       throw new Error("When canonicalization method is non-exclusive, whole xml dom must be provided as an argument");
     }
     
-    ancestorNamespaces = findAncestorNs(doc, "//*[local-name()='SignedInfo']");
   }
-  
+  ancestorNamespaces = findAncestorNs(doc, "//*[local-name()='SignedInfo']");
+
   var c14nOptions = {
     ancestorNamespaces: ancestorNamespaces
   };
@@ -465,10 +465,7 @@ SignedXml.prototype.validateReferences = function(doc) {
           break;
         }
       }
-    
-      if(hasNonExcC14nTransform){
-        ref.ancestorNamespaces = findAncestorNs(doc, elemXpath);
-      }
+      ref.ancestorNamespaces = findAncestorNs(doc, elemXpath);
     }
   
     var c14nOptions = {

--- a/test/canonicalization-unit-tests.js
+++ b/test/canonicalization-unit-tests.js
@@ -4,14 +4,15 @@ var ExclusiveCanonicalization = require("../lib/exclusive-canonicalization").Exc
   , SignedXml = require('../lib/signed-xml.js').SignedXml
 
 
-var compare = function(test, xml, xpath, expected, inclusiveNamespacesPrefixList, defaultNsForPrefix) {
+var compare = function(test, xml, xpath, expected, inclusiveNamespacesPrefixList, defaultNsForPrefix, ancestorNamespaces) {
     test.expect(1)
     var doc = new Dom().parseFromString(xml)
     var elem = select(doc, xpath)[0]
     var can = new ExclusiveCanonicalization()
     var result = can.process(elem, {
       inclusiveNamespacesPrefixList: inclusiveNamespacesPrefixList,
-      defaultNsForPrefix: defaultNsForPrefix
+      defaultNsForPrefix: defaultNsForPrefix,
+      ancestorNamespaces: ancestorNamespaces
     }).toString()
 
     test.equal(expected, result)
@@ -442,5 +443,14 @@ module.exports = {
             '//*',
             '<ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:InclusiveNamespaces xmlns:ds="http://www.w3.org/2001/10/xml-exc-c14n#"></ds:InclusiveNamespaces></ds:Signature>',
             'ds')
+  },
+
+  "An ancestor namespace, which is included in the inclusiveNamespacePrefixList should be added to the top level element": function (test) {
+    compare(test, '<root><child inclusive:attr="value"></child></root>',
+            '//*',
+             '<root xmlns:inclusive="urn:inclusive"><child inclusive:attr="value"></child></root>',
+      "inclusive",
+      {},
+      [{"prefix": "inclusive", "namespaceURI": "urn:inclusive"}]);
   }
 }


### PR DESCRIPTION
… where non-exclusive and thus written out on the root note of the canonical document.

According to the WC3 specification, namespaces in the inclusive namespace list should be treated as if by the exclusive algorithm. For a document subset, the exclusive algorithm copies namespaces from ancestor nodes to the root of the document in canonical from (see https://www.w3.org/TR/xml-c14n11/#Example-DocSubsets)

This patch ensures that such ancestor namespaces are treated correctly as well as adding a test for this behavior.

