### PR TITLE
Merge one round of changes from Auth0

### DIFF
--- a/lib/signed-xml.js
+++ b/lib/signed-xml.js
@@ -293,12 +293,34 @@ SignedXml.prototype.validateReferences = function(doc) {
                         ref.uri + " but could not find such element in the xml")
       return false
     }
-    var canonXml = this.getCanonXml(ref.transforms, elem[0], { inclusiveNamespacesPrefixList: ref.inclusiveNamespacesPrefixList });        
 
-    var hash = this.findHashAlgorithm(ref.digestAlgorithm)    
-    var digest = hash.getHash(canonXml)    
+    var canonXml = this.getCanonXml(ref.transforms, elem[0], { inclusiveNamespacesPrefixList: ref.inclusiveNamespacesPrefixList });
+    var hash = this.findHashAlgorithm(ref.digestAlgorithm);
+    var digest = hash.getHash(canonXml);
     
-    if (digest!=ref.digestValue) {      
+    if (digest!=ref.digestValue) {
+      if (ref.inclusiveNamespacesPrefixList) {
+        // fallback: apply InclusiveNamespaces workaround (https://github.com/yaronn/xml-crypto/issues/72)
+        var prefixList = ref.inclusiveNamespacesPrefixList instanceof Array ? ref.inclusiveNamespacesPrefixList : ref.inclusiveNamespacesPrefixList.split(' ');
+        var supported_definitions = {
+          'xs': 'http://www.w3.org/2001/XMLSchema',
+          'xsi': 'http://www.w3.org/2001/XMLSchema-instance',
+          'saml': 'urn:oasis:names:tc:SAML:2.0:assertion'
+        }
+
+        prefixList.forEach(function (prefix) {
+          if (supported_definitions[prefix]) {
+            elem[0].setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:' + prefix, supported_definitions[prefix]);
+          }
+        });
+
+        canonXml = this.getCanonXml(ref.transforms, elem[0], { inclusiveNamespacesPrefixList: ref.inclusiveNamespacesPrefixList });
+        digest = hash.getHash(canonXml);
+        if (digest === ref.digestValue) {
+          return true;
+        }
+      }
+
       this.validationErrors.push("invalid signature: for uri " + ref.uri +
                                 " calculated digest is "  + digest +
                                 " but the xml to validate supplies digest " + ref.digestValue + ". XML: [[" + this.signedXml + "]]. Cannon XML: [[" + canonXml + "]]");

--- a/lib/signed-xml.js
+++ b/lib/signed-xml.js
@@ -251,7 +251,7 @@ SignedXml.prototype.validateReferences = function(doc) {
     if (digest!=ref.digestValue) {      
       this.validationErrors.push("invalid signature: for uri " + ref.uri +
                                 " calculated digest is "  + digest +
-                                " but the xml to validate supplies digest " + ref.digestValue)
+                                " but the xml to validate supplies digest " + ref.digestValue + ". XML: " + doc.toString());
 
       return false
     }

--- a/lib/signed-xml.js
+++ b/lib/signed-xml.js
@@ -251,7 +251,7 @@ SignedXml.prototype.validateReferences = function(doc) {
     if (digest!=ref.digestValue) {      
       this.validationErrors.push("invalid signature: for uri " + ref.uri +
                                 " calculated digest is "  + digest +
-                                " but the xml to validate supplies digest " + ref.digestValue + ". XML: " + doc.toString());
+                                " but the xml to validate supplies digest " + ref.digestValue + ". XML: [[" + this.signedXml + "]]. Cannon XML: [[" + canonXml + "]]");
 
       return false
     }

--- a/lib/signed-xml.js
+++ b/lib/signed-xml.js
@@ -57,6 +57,20 @@ function SHA256() {
   }
 }
 
+function SHA512() {
+  
+  this.getHash = function(xml) {    
+    var shasum = crypto.createHash('sha512')
+    shasum.update(xml, 'utf8')
+    var res = shasum.digest('base64')
+    return res
+  }
+
+  this.getAlgorithmName = function() {
+    return "http://www.w3.org/2001/04/xmlenc#sha512"
+  }
+}
+
 
 /**
  * Signature algorithm implementation
@@ -126,6 +140,40 @@ function RSASHA256() {
 
 }
 
+/**
+ * Signature algorithm implementation
+ *
+ */
+function RSASHA512() {
+  
+  /**
+  * Sign the given string using the given key
+  *
+  */
+  this.getSignature = function(signedInfo, signingKey) {            
+    var signer = crypto.createSign("RSA-SHA512")
+    signer.update(signedInfo)    
+    var res = signer.sign(signingKey, 'base64')
+    return res
+  }
+
+  /**
+  * Verify the given signature of the given string using key
+  *
+  */
+  this.verifySignature = function(str, key, signatureValue) {
+    var verifier = crypto.createVerify("RSA-SHA512")
+    verifier.update(str)
+    var res = verifier.verify(key, signatureValue, 'base64')
+    return res
+  }
+
+  this.getAlgorithmName = function() {
+    return "http://www.w3.org/2001/04/xmldsig-more#rsa-sha512"
+  }
+
+}
+
 
 /**
 * Xml signature implementation
@@ -159,12 +207,14 @@ SignedXml.CanonicalizationAlgorithms = {
 
 SignedXml.HashAlgorithms = {
   'http://www.w3.org/2000/09/xmldsig#sha1': SHA1,
-  'http://www.w3.org/2001/04/xmlenc#sha256': SHA256
+  'http://www.w3.org/2001/04/xmlenc#sha256': SHA256,
+  'http://www.w3.org/2001/04/xmlenc#sha512': SHA512
 }
 
 SignedXml.SignatureAlgorithms = {
   'http://www.w3.org/2000/09/xmldsig#rsa-sha1': RSASHA1,
-  'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256': RSASHA256
+  'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256': RSASHA256,
+  'http://www.w3.org/2001/04/xmldsig-more#rsa-sha512': RSASHA512
 }
 
 SignedXml.prototype.checkSignature = function(xml) {

--- a/lib/signed-xml.js
+++ b/lib/signed-xml.js
@@ -281,7 +281,7 @@ SignedXml.prototype.loadSignature = function(signatureXml) {
   }
 
   this.signatureValue = 
-    utils.findFirst(doc, "//*[local-name(.)='SignatureValue']/text()").data.replace(/\n/g, '')
+    utils.findFirst(doc, "//*[local-name(.)='SignatureValue']/text()").data.replace(/[\r|\n]/g, '')
 
   this.keyInfo = select(doc, "//*[local-name(.)='KeyInfo']")  
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -19,6 +19,7 @@ function findFirst(doc, xpath) {
 }
 
 function findChilds(node, localName, namespace) {
+  node = node.documentElement || node;
   var res = []
   for (var i = 0; i<node.childNodes.length; i++) {
     var child = node.childNodes[i]       

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -54,6 +54,7 @@ var escaped_one_to_xml_special_map = {
 }
  
 function normalizeXmlIncludingCR(string) {
+    string = string.replace(/\r\n/g, '\n');
     return string.replace(/([\&"<>\r])/g, function(str, item) {
         return xml_special_to_escaped_one_map[item];
     })

--- a/test/canonicalization-unit-tests.js
+++ b/test/canonicalization-unit-tests.js
@@ -10,7 +10,6 @@ var compare = function(test, xml, xpath, expected, inclusiveNamespacesPrefixList
     var elem = select(doc, xpath)[0]
     var can = new ExclusiveCanonicalization()
     var result = can.process(elem, { inclusiveNamespacesPrefixList: inclusiveNamespacesPrefixList }).toString()
-    
     test.equal(expected, result)
     test.done()
 }
@@ -318,6 +317,14 @@ module.exports = {
       "//*[local-name(.)='Body']", 
       "<Body xmlns=\"http://schemas.xmlsoap.org/soap/envelope/\">&#xD;    <ACORD xmlns=\"http://www.ACORD.org/standards/PC_Surety/ACORD1.10.0/xml/\">&#xD;      <SignonRq>&#xD;        <SessKey></SessKey>&#xD;        <ClientDt></ClientDt>&#xD;        <CustLangPref></CustLangPref>&#xD;        <ClientApp>&#xD;          <Org xmlns:p6=\"http://www.w3.org/2001/XMLSchema-instance\" id=\"wewe\" p6:type=\"AssignedIdentifier\"></Org>&#xD;          <Name></Name>&#xD;          <Version></Version>&#xD;        </ClientApp>&#xD;        <ProxyClient>&#xD;          <Org xmlns:p6=\"http://www.w3.org/2001/XMLSchema-instance\" id=\"erer\" p6:type=\"AssignedIdentifier\"></Org>&#xD;          <Name>ererer</Name>&#xD;          <Version>dfdf</Version>&#xD;        </ProxyClient>&#xD;      </SignonRq>&#xD;      <InsuranceSvcRq>&#xD;        <RqUID></RqUID>&#xD;        <SPName id=\"rter\"></SPName>&#xD;        <QuickHit xmlns=\"urn:com.thehartford.bi.acord-extensions\">&#xD;          <StateProvCd xmlns=\"http://www.ACORD.org/standards/PC_Surety/ACORD1.10.0/xml/\" CodeListRef=\"dfdf\"></StateProvCd>&#xD;        </QuickHit>&#xD;        <WorkCompPolicyQuoteInqRq>&#xD;          <RqUID>erer</RqUID>&#xD;          <TransactionRequestDt id=\"erer\"></TransactionRequestDt>&#xD;          <CurCd></CurCd>&#xD;          <BroadLOBCd id=\"erer\"></BroadLOBCd>&#xD;          <InsuredOrPrincipal>&#xD;            <ItemIdInfo>&#xD;              <AgencyId id=\"3434\"></AgencyId>&#xD;              <OtherIdentifier>&#xD;                <CommercialName id=\"3434\"></CommercialName>&#xD;                <ContractTerm>&#xD;                  <EffectiveDt id=\"3434\"></EffectiveDt>&#xD;                  <StartTime id=\"3434\"></StartTime>&#xD;                </ContractTerm>&#xD;              </OtherIdentifier>&#xD;            </ItemIdInfo>&#xD;          </InsuredOrPrincipal>&#xD;          <InsuredOrPrincipal>&#xD;          </InsuredOrPrincipal>&#xD;          <CommlPolicy>&#xD;            <PolicyNumber id=\"3434\"></PolicyNumber>&#xD;            <LOBCd></LOBCd>&#xD;          </CommlPolicy>&#xD;          <WorkCompLineBusiness>&#xD;            <LOBCd></LOBCd>&#xD;            <WorkCompRateState>&#xD;              <WorkCompLocInfo>&#xD;              </WorkCompLocInfo>&#xD;            </WorkCompRateState>&#xD;          </WorkCompLineBusiness>&#xD;          <RemarkText IdRef=\"\">&#xD;          </RemarkText>&#xD;          <RemarkText IdRef=\"2323\" id=\"3434\">&#xD;          </RemarkText>&#xD;        </WorkCompPolicyQuoteInqRq>&#xD;      </InsuranceSvcRq>&#xD;    </ACORD>&#xD;  </Body>")
   },
+
+  "Should replace \\r\\n with \\n": function (test) {
+    compare(test, 
+      "<foo><bar>\r\ntest</bar></foo>", 
+      "//*[local-name(.)='bar']", 
+      "<bar>\ntest</bar>")
+  }, 
+
 
   "Multiple Canonicalization with namespace definition outside of signed element": function (test) {
       //var doc = new Dom().parseFromString("<x xmlns:p=\"myns\"><p:y><ds:Signature xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\"></ds:Signature></p:y></x>")


### PR DESCRIPTION
The Auth0 fork of xml-crypto contains changes that add/fix the following:

Fixes #72 
Add support for SHA512 for hashing and signature generation
Remove CR characters common on Windows systems