### PR TITLE
fix for enveloped signatures

### DIFF
--- a/lib/enveloped-signature.js
+++ b/lib/enveloped-signature.js
@@ -1,13 +1,29 @@
 var xpath = require('xpath');
+var utils = require('./utils');
 
 exports.EnvelopedSignature = EnvelopedSignature;
 
 function EnvelopedSignature() {
 }
 
-EnvelopedSignature.prototype.process = function (node) {
-  var signature = xpath.select("./*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']", node)[0];  
-  if (signature) signature.parentNode.removeChild(signature);
+EnvelopedSignature.prototype.process = function (node, options) {
+  if (null == options.signatureNode) {
+    // leave this for the moment...
+    var signature = xpath.select("./*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']", node)[0];
+    if (signature) signature.parentNode.removeChild(signature);
+    return node;
+  }
+  var signatureNode = options.signatureNode;
+  var expectedSignatureValue = utils.findFirst(signatureNode, ".//*[local-name(.)='SignatureValue']/text()").data;
+  var signatures = xpath.select(".//*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']", node);
+  for (var h in signatures) {
+    if (!signatures.hasOwnProperty(h)) continue;
+    var signature = signatures[h];
+    var signatureValue = utils.findFirst(signature, ".//*[local-name(.)='SignatureValue']/text()").data;
+    if (expectedSignatureValue === signatureValue) {
+      signature.parentNode.removeChild(signature);
+    }
+  }
   return node;
 };
 

--- a/lib/signed-xml.js
+++ b/lib/signed-xml.js
@@ -815,6 +815,7 @@ SignedXml.prototype.createReferences = function(doc, prefix) {
 SignedXml.prototype.getCanonXml = function(transforms, node, options) {
   options = options || {};
   options.defaultNsForPrefix = options.defaultNsForPrefix || SignedXml.defaultNsForPrefix;
+  options.signatureNode = this.signatureNode;
 
   var canonXml = node.cloneNode(true) // Deep clone
 


### PR DESCRIPTION
This patch really makes sure that we only cut out the signature in which our enveloped signature transformation is defined. For the moment this is based on the signature value...