### PR TITLE
Add top-level support for namespaces

### DIFF
--- a/lib/signed-xml.js
+++ b/lib/signed-xml.js
@@ -207,13 +207,13 @@ function HMACSHA1() {
  * @param {string} docSubsetXpath - xpath query to get document subset being canonicalized
  * @returns {Array} i.e. [{prefix: "saml", namespaceURI: "urn:oasis:names:tc:SAML:2.0:assertion"}]
  */
-function findAncestorNs(doc, docSubsetXpath){
-  var docSubset = xpath.select(docSubsetXpath, doc);
-  
+function findAncestorNs(doc, docSubsetXpath, xpath){
+  var docSubset = xpath(docSubsetXpath, doc);
+
   if(!Array.isArray(docSubset) || docSubset.length < 1){
     return [];
   }
-  
+
   // Remove duplicate on ancestor namespace
   var ancestorNs = collectAncestorNamespaces(docSubset[0]);
   var ancestorNsWithoutDuplicate = [];
@@ -225,12 +225,12 @@ function findAncestorNs(doc, docSubsetXpath){
         break;
       }
     }
-    
+
     if(notOnTheList){
       ancestorNsWithoutDuplicate.push(ancestorNs[i]);
     }
   }
-  
+
   // Remove namespaces which are already declared in the subset with the same prefix
   var returningNs = [];
   var subsetAttributes = docSubset[0].attributes;
@@ -245,12 +245,12 @@ function findAncestorNs(doc, docSubsetXpath){
         break;
       }
     }
-  
+
     if(isUnique){
       returningNs.push(ancestorNsWithoutDuplicate[j]);
     }
   }
-  
+
   return returningNs;
 }
 
@@ -260,13 +260,13 @@ function collectAncestorNamespaces(node, nsArray){
   if(!nsArray){
     nsArray = [];
   }
-  
+
   var parent = node.parentNode;
-  
+
   if(!parent){
     return nsArray;
   }
-  
+
   if(parent.attributes && parent.attributes.length > 0){
     for(var i=0;i<parent.attributes.length;i++){
       var attr = parent.attributes[i];
@@ -275,7 +275,7 @@ function collectAncestorNamespaces(node, nsArray){
       }
     }
   }
-  
+
   return collectAncestorNamespaces(parent, nsArray);
 }
 
@@ -302,6 +302,8 @@ function SignedXml(idMode, options) {
   this.validationErrors = []
   this.keyInfo = null
   this.idAttributes = [ 'Id', 'ID', 'id' ];
+  this.namespaces = this.options.namespaces || {}
+  this.xpath = xpath.useNamespaces(this.namespaces)
   if (this.options.idAttribute) this.idAttributes.splice(0, 0, this.options.idAttribute);
   this.implicitTransforms = this.options.implicitTransforms || [];
 }
@@ -349,7 +351,7 @@ SignedXml.prototype.checkSignature = function(xml) {
   if (!this.validateReferences(doc)) {
     return false;
   }
-  
+
   if (!this.validateSignatureValue(doc)) {
     return false;
   }
@@ -360,7 +362,7 @@ SignedXml.prototype.checkSignature = function(xml) {
 SignedXml.prototype.validateSignatureValue = function(doc) {
   var signedInfo = utils.findChilds(this.signatureNode, "SignedInfo")
   if (signedInfo.length==0) throw new Error("could not find SignedInfo element in the message")
-  
+
   if(this.canonicalizationAlgorithm === "http://www.w3.org/TR/2001/REC-xml-c14n-20010315"
   || this.canonicalizationAlgorithm === "http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments")
   {
@@ -368,13 +370,13 @@ SignedXml.prototype.validateSignatureValue = function(doc) {
       throw new Error("When canonicalization method is non-exclusive, whole xml dom must be provided as an argument");
     }
   }
-  
+
   /**
    * Search for ancestor namespaces before validating signature.
    */
   var ancestorNamespaces = [];
-  ancestorNamespaces = findAncestorNs(doc, "//*[local-name()='SignedInfo']");
-  
+  ancestorNamespaces = findAncestorNs(doc, "//*[local-name()='SignedInfo']", this.xpath);
+
   var c14nOptions = {
     ancestorNamespaces: ancestorNamespaces
   };
@@ -416,7 +418,7 @@ SignedXml.prototype.validateReferences = function(doc) {
     var elemXpath;
 
     if (uri=="") {
-      elem = xpath.select("//*", doc)
+      elem = this.xpath("//*", doc)
     }
     else if (uri.indexOf("'") != -1) {
       // xpath injection
@@ -427,7 +429,7 @@ SignedXml.prototype.validateReferences = function(doc) {
       for (var index in this.idAttributes) {
         if (!this.idAttributes.hasOwnProperty(index)) continue;
         var tmp_elemXpath = "//*[@*[local-name(.)='" + this.idAttributes[index] + "']='" + uri + "']";
-        var tmp_elem = xpath.select(tmp_elemXpath, doc)
+        var tmp_elem = this.xpath(tmp_elemXpath, doc)
         num_elements_for_id += tmp_elem.length;
         if (tmp_elem.length > 0) {
           elem = tmp_elem;
@@ -446,14 +448,14 @@ SignedXml.prototype.validateReferences = function(doc) {
                         ref.uri + " but could not find such element in the xml")
       return false
     }
-  
+
     /**
      * Search for ancestor namespaces before validating references.
      */
-    if(Array.isArray(ref.transforms)){  
-      ref.ancestorNamespaces = findAncestorNs(doc, elemXpath);
+    if(Array.isArray(ref.transforms)){
+      ref.ancestorNamespaces = findAncestorNs(doc, elemXpath, this.xpath);
     }
-  
+
     var c14nOptions = {
       inclusiveNamespacesPrefixList: ref.inclusiveNamespacesPrefixList,
       ancestorNamespaces: ref.ancestorNamespaces
@@ -516,7 +518,7 @@ SignedXml.prototype.loadSignature = function(signatureNode) {
 
   this.signatureXml = signatureNode.toString();
 
-  var nodes = xpath.select(".//*[local-name(.)='CanonicalizationMethod']/@Algorithm", signatureNode)
+  var nodes = this.xpath(".//*[local-name(.)='CanonicalizationMethod']/@Algorithm", signatureNode)
   if (nodes.length==0) throw new Error("could not find CanonicalizationMethod/@Algorithm element")
   this.canonicalizationAlgorithm = nodes[0].value
 
@@ -524,7 +526,7 @@ SignedXml.prototype.loadSignature = function(signatureNode) {
     utils.findFirst(signatureNode, ".//*[local-name(.)='SignatureMethod']/@Algorithm").value
 
   this.references = []
-  var references = xpath.select(".//*[local-name(.)='SignedInfo']/*[local-name(.)='Reference']", signatureNode)
+  var references = this.xpath(".//*[local-name(.)='SignedInfo']/*[local-name(.)='Reference']", signatureNode)
   if (references.length == 0) throw new Error("could not find any Reference elements")
 
   for (var i in references) {
@@ -536,7 +538,7 @@ SignedXml.prototype.loadSignature = function(signatureNode) {
   this.signatureValue =
     utils.findFirst(signatureNode, ".//*[local-name(.)='SignatureValue']/text()").data.replace(/\r?\n/g, '')
 
-  this.keyInfo = xpath.select(".//*[local-name(.)='KeyInfo']", signatureNode)
+  this.keyInfo = this.xpath(".//*[local-name(.)='KeyInfo']", signatureNode)
 }
 
 /**
@@ -592,7 +594,7 @@ SignedXml.prototype.loadReference = function(ref) {
       transforms.push(t);
     });
   }
-  
+
 /**
  * DigestMethods take an octet stream rather than a node set. If the output of the last transform is a node set, we
  * need to canonicalize the node set to an octet stream using non-exclusive canonicalization. If there are no
@@ -700,7 +702,7 @@ SignedXml.prototype.computeSignature = function(xml, opts) {
   var xml = new Dom().parseFromString(dummySignatureWrapper)
   var signatureDoc = xml.documentElement.firstChild;
 
-  var referenceNode = xpath.select(location.reference, doc);
+  var referenceNode = this.xpath(location.reference, doc);
 
   if (!referenceNode || referenceNode.length === 0) {
     throw new Error("the following xpath cannot be used because it was not found: " + location.reference);
@@ -751,7 +753,7 @@ SignedXml.prototype.createReferences = function(doc, prefix) {
     if (!this.references.hasOwnProperty(n)) continue;
 
     var ref = this.references[n]
-      , nodes = xpath.select(ref.xpath, doc)
+      , nodes = this.xpath(ref.xpath, doc)
 
     if (nodes.length==0) {
       throw new Error('the following xpath cannot be signed because it was not found: ' + ref.xpath)


### PR DESCRIPTION
Namespace support is a little bit wacky. I'm adding the following option:
```js
var sig = new SignedXml(null, {
    namespaces: {
        soap: 'http://schemas.xmlsoap.org/soap/envelope/',
        wsu: 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd',
        wsse: 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd',
    }
})
```