### PR TITLE
Don't encode windows line-breaks with special characters.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -65,7 +65,7 @@ function encodeSpecialCharactersInAttribute(attributeValue){
 
 function encodeSpecialCharactersInText(text){
     return text
-	      .replace(/\r\n/g, '\n')  // Line ending normalization (Note: this should normally be done by the xml parser). See: https://www.w3.org/TR/xml/#sec-line-ends
+	.replace(/\r\n/g, '\n')  // Line ending normalization (Note: this should normally be done by the xml parser). See: https://www.w3.org/TR/xml/#sec-line-ends
         .replace(/([&<>\r])/g, function(str, item){
             // Special character normalization. See:
             // - https://www.w3.org/TR/xml-c14n#ProcessingModel (Text Nodes)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -65,7 +65,7 @@ function encodeSpecialCharactersInAttribute(attributeValue){
 
 function encodeSpecialCharactersInText(text){
     return text
-	      .replace(/\r\n?/g, '\n')  // Line ending normalization (Note: this should normally be done by the xml parser). See: https://www.w3.org/TR/xml/#sec-line-ends
+	      .replace(/\r\n/g, '\n')  // Line ending normalization (Note: this should normally be done by the xml parser). See: https://www.w3.org/TR/xml/#sec-line-ends
         .replace(/([&<>\r])/g, function(str, item){
             // Special character normalization. See:
             // - https://www.w3.org/TR/xml-c14n#ProcessingModel (Text Nodes)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -65,6 +65,7 @@ function encodeSpecialCharactersInAttribute(attributeValue){
 
 function encodeSpecialCharactersInText(text){
     return text
+	      .replace(/\r\n?/g, '\n')  // Line ending normalization (Note: this should normally be done by the xml parser). See: https://www.w3.org/TR/xml/#sec-line-ends
         .replace(/([&<>\r])/g, function(str, item){
             // Special character normalization. See:
             // - https://www.w3.org/TR/xml-c14n#ProcessingModel (Text Nodes)

--- a/test/canonicalization-unit-tests.js
+++ b/test/canonicalization-unit-tests.js
@@ -207,11 +207,11 @@ module.exports = {
       "<child><inner>12\n3\t</inner></child>")
   },
 
-  "Exclusive canonicalization does not alter CR-NL (windows line separator) sequences": function(test){
+  "Exclusive canonicalization does alter CR-NL (windows line separator) sequences": function(test){
     compare(test,
         "<root><child><inner>123</inner>\r\n</child></root>",
         "//*[local-name(.)='child']",
-        "<child><inner>123</inner>&#xD;\n</child>")
+        "<child><inner>123</inner>\n</child>")
   },
 
   "Exclusive canonicalization preserves and encodes CR white space": function(test){


### PR DESCRIPTION
Getting "Invalid Signature". The line breaks are getting encoded as special characters which botch the signature checking.