### PR TITLE
[Security] Bump xmldom version 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3597,9 +3597,8 @@
       }
     },
     "xmldom": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
-      "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg=="
+      "version": "git+ssh://git@github.com/xmldom/xmldom.git#c568938641cc1f121cef5b4df80fcfda1e489b6e",
+      "from": "xmldom@github:xmldom/xmldom#0.7.0"
     },
     "xpath": {
       "version": "0.0.32",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "LoneRifle <LoneRifle@users.noreply.github.com>"
   ],
   "dependencies": {
-    "xmldom": "^0.6.0",
+    "xmldom": "github:xmldom/xmldom#0.7.0",
     "xpath": "0.0.32"
   },
   "devDependencies": {


### PR DESCRIPTION
There is a vulnerability in the used version of xmldom, an update has been released under the version 0.7.0 however the developers lost access to npm.

As of right now the only way to update the dependency is by pointing to the Github release.

More information can be found here.

Advisory: xmldom/xmldom#270
NPM Issues: xmldom/xmldom#271