### PR TITLE
Correct behavior for XML canonicalization with namespaces and nested elements

### DIFF
--- a/lib/c14n-canonicalization.js
+++ b/lib/c14n-canonicalization.js
@@ -208,7 +208,13 @@ C14nCanonicalization.prototype.process = function(node, options) {
   var defaultNsForPrefix = options.defaultNsForPrefix || {};
   var ancestorNamespaces = options.ancestorNamespaces || [];
 
-  var res = this.processInner(node, [], defaultNs, defaultNsForPrefix, ancestorNamespaces);
+  var prefixesInScope = [];
+  for (var i = 0; i < ancestorNamespaces.length; i++) {
+    prefixesInScope.push(ancestorNamespaces[i].prefix)
+  }
+
+  console.log({prefixesInScope})
+  var res = this.processInner(node, prefixesInScope, defaultNs, defaultNsForPrefix, ancestorNamespaces);
   return res;
 };
 

--- a/lib/c14n-canonicalization.js
+++ b/lib/c14n-canonicalization.js
@@ -210,7 +210,7 @@ C14nCanonicalization.prototype.process = function(node, options) {
 
   var prefixesInScope = [];
   for (var i = 0; i < ancestorNamespaces.length; i++) {
-    prefixesInScope.push(ancestorNamespaces[i].prefix)
+    prefixesInScope.push(ancestorNamespaces[i].prefix);
   }
 
   var res = this.processInner(node, prefixesInScope, defaultNs, defaultNsForPrefix, ancestorNamespaces);

--- a/lib/c14n-canonicalization.js
+++ b/lib/c14n-canonicalization.js
@@ -213,7 +213,6 @@ C14nCanonicalization.prototype.process = function(node, options) {
     prefixesInScope.push(ancestorNamespaces[i].prefix)
   }
 
-  console.log({prefixesInScope})
   var res = this.processInner(node, prefixesInScope, defaultNs, defaultNsForPrefix, ancestorNamespaces);
   return res;
 };

--- a/test/c14n-non-exclusive-unit-test.js
+++ b/test/c14n-non-exclusive-unit-test.js
@@ -180,7 +180,7 @@ exports["C14n: Don't redeclare an attribute's namespace prefix if already in sco
 exports["C14n: Don't declare an attribute's namespace prefix if in scope from parent"] = function(test) {
   var xml = "<root xmlns:aaa='bbb'><child1><child2><child3 aaa:foo='bar'></child3></child2></child1></root>"
   var xpath = "/root/child1";
-  var expected = "<child1 xmlns:aaa='bbb'><child2><child3 aaa:foo='bar'></child3></child2></child1>";
+  var expected = '<child1 xmlns:aaa="bbb"><child2><child3 aaa:foo="bar"></child3></child2></child1>';
 
   test_C14nCanonicalization(test, xml, xpath, expected);
 }

--- a/test/c14n-non-exclusive-unit-test.js
+++ b/test/c14n-non-exclusive-unit-test.js
@@ -176,3 +176,11 @@ exports["C14n: Don't redeclare an attribute's namespace prefix if already in sco
 
   test_C14nCanonicalization(test, xml, xpath, expected);
 }
+
+exports["C14n: Don't declare an attribute's namespace prefix if in scope from parent"] = function(test) {
+  var xml = "<root xmlns:aaa='bbb'><child1><child2><child3 aaa:foo='bar'></child3></child2></child1></root>"
+  var xpath = "/root/child1";
+  var expected = "<child1 xmlns:aaa='bbb'><child2><child3 aaa:foo='bar'></child3></child2></child1>";
+
+  test_C14nCanonicalization(test, xml, xpath, expected);
+}


### PR DESCRIPTION
Hey there! I wanted to start by saying thank you for the hard work maintaining this package.

I've been running into problems related to mismatched signature digests when validating a signed XML document, and I've narrowed the mismatch down to differences in how this library and another canonicalize the document. While the real world example involves SAML response XML, I've tried to instead demonstrate the behavior with a minimal failing test.

For the `http://www.w3.org/TR/2001/REC-xml-c14n-20010315` method, I noticed that `xml-crypto` seems to be repeating namespaces that are already defined on an ancestor node.

If we start with this document...

```xml
<root xmlns:aaa='bbb'>
  <child1>
    <child2>
      <child3 aaa:foo='bar'>
      </child3>
    </child2>
  </child1>
</root>
```

...and like in the test, canonicalize the subset of the document with `child1`, we get...

```xml
<child1 xmlns:aaa="bbb">
  <child2>
    <child3 xmlns:aaa="bbb" aaa:foo="bar">
    </child3>
  </child2>
</child1>
```

Notice that `xmlns:aaa` gets pushed down from the `root` to `child1`, which I expect, but then the namespace is also repeated on `child3`.

Is this expected behavior? It seems incorrect, due to the duplication of `xmlns:aaa`.