### PR TITLE
Bug: Enveloped signature skipped when comparison falsy

### DIFF
--- a/lib/enveloped-signature.js
+++ b/lib/enveloped-signature.js
@@ -14,12 +14,12 @@ EnvelopedSignature.prototype.process = function (node, options) {
     return node;
   }
   var signatureNode = options.signatureNode;
-  var expectedSignatureValue = utils.findFirst(signatureNode, ".//*[local-name(.)='SignatureValue']/text()").data;
+  var expectedSignatureValue = utils.findFirst(signatureNode, ".//*[local-name(.)='SignatureValue']/text()").data.replace(/\r?\n/g, '');
   var signatures = xpath.select(".//*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']", node);
   for (var h in signatures) {
     if (!signatures.hasOwnProperty(h)) continue;
     var signature = signatures[h];
-    var signatureValue = utils.findFirst(signature, ".//*[local-name(.)='SignatureValue']/text()").data;
+    var signatureValue = utils.findFirst(signature, ".//*[local-name(.)='SignatureValue']/text()").data.replace(/\r?\n/g, '');
     if (expectedSignatureValue === signatureValue) {
       signature.parentNode.removeChild(signature);
     }


### PR DESCRIPTION
As mentioned in the issue #259, EnvelopedSignature is skipped when `options.signatureNode` is provided and the comparison between the two signatures includes non-matching invisible chars.


Closes #259